### PR TITLE
Refactor/namespace constants

### DIFF
--- a/src/components/android-settings-container.js
+++ b/src/components/android-settings-container.js
@@ -10,6 +10,7 @@ import {
     maxValues,
 } from '../constants/android-settings'
 import AndroidSettings from './android-settings'
+import { NAMESPACE, GENERAL_SETTINGS } from '../constants/data-store'
 
 const { metadataSync, dataSync, encryptDB } = androidSettingsDefault
 
@@ -88,19 +89,15 @@ class AndroidSettingsContainer extends React.Component {
     }
 
     saveDataApi = data => {
-        this.keyName === 'android_settings'
+        this.keyName === GENERAL_SETTINGS
             ? api
-                  .updateValue('ANDROID_SETTING_APP', 'android_settings', data)
+                  .updateValue(NAMESPACE, GENERAL_SETTINGS, data)
                   .then(res => res)
             : api
-                  .getKeys('ANDROID_SETTING_APP')
+                  .getKeys(NAMESPACE)
                   .then(
                       api
-                          .createValue(
-                              'ANDROID_SETTING_APP',
-                              'android_settings',
-                              data
-                          )
+                          .createValue(NAMESPACE, GENERAL_SETTINGS, data)
                           .then(res => res)
                   )
     }
@@ -125,19 +122,17 @@ class AndroidSettingsContainer extends React.Component {
         await api
             .getNamespaces()
             .then(res => {
-                const nameSpace = res.filter(
-                    name => name === 'ANDROID_SETTING_APP'
-                )
+                const nameSpace = res.filter(name => name === NAMESPACE)
                 nameSpace.length === 0
                     ? (this.nameSpace = undefined)
                     : (this.nameSpace = nameSpace[0])
                 this.nameSpace !== undefined
                     ? this.setState({ isUpdated: true })
                     : this.setState({ isUpdated: false })
-                if (this.nameSpace === 'ANDROID_SETTING_APP') {
+                if (this.nameSpace === NAMESPACE) {
                     api.getKeys(this.nameSpace).then(res => {
                         const keyName = res.filter(
-                            name => name === 'android_settings'
+                            name => name === GENERAL_SETTINGS
                         )
                         keyName.length === 0
                             ? (this.keyName = undefined)
@@ -154,18 +149,14 @@ class AndroidSettingsContainer extends React.Component {
                                       })
                                   })
                             : api
-                                  .updateValue(
-                                      'ANDROID_SETTING_APP',
-                                      'android_settings',
-                                      {
-                                          metadataSync: metadataSync,
-                                          dataSync: dataSync,
-                                          numberSmsToSend: '',
-                                          numberSmsConfirmation: '',
-                                          valuesTEI: '',
-                                          encryptDB: encryptDB,
-                                      }
-                                  )
+                                  .createValue(NAMESPACE, GENERAL_SETTINGS, {
+                                      metadataSync: metadataSync,
+                                      dataSync: dataSync,
+                                      numberSmsToSend: '',
+                                      numberSmsConfirmation: '',
+                                      valuesTEI: '',
+                                      encryptDB: encryptDB,
+                                  })
                                   .then(res => {
                                       this.setState({
                                           metadataSync: metadataSync,
@@ -174,16 +165,15 @@ class AndroidSettingsContainer extends React.Component {
                                           numberSmsConfirmation: '',
                                           valuesTEI: '',
                                           encryptDB: encryptDB,
+                                          isUpdated: true,
+                                          loading: false,
                                       })
                                   })
                     })
                 } else if (this.nameSpace === undefined) {
-                    api.createNamespace(
-                        'ANDROID_SETTING_APP',
-                        'android_settings'
-                    )
+                    api.createNamespace(NAMESPACE, GENERAL_SETTINGS)
                         .then(res => {
-                            this.keyName = 'android_settings'
+                            this.keyName = GENERAL_SETTINGS
                             this.setState({
                                 isUpdated: true,
                                 loading: false,

--- a/src/components/android-settings-container.js
+++ b/src/components/android-settings-container.js
@@ -149,7 +149,7 @@ class AndroidSettingsContainer extends React.Component {
                                       })
                                   })
                             : api
-                                  .createValue(NAMESPACE, GENERAL_SETTINGS, {
+                                  .updateValue(NAMESPACE, GENERAL_SETTINGS, {
                                       metadataSync: metadataSync,
                                       dataSync: dataSync,
                                       numberSmsToSend: '',
@@ -165,8 +165,6 @@ class AndroidSettingsContainer extends React.Component {
                                           numberSmsConfirmation: '',
                                           valuesTEI: '',
                                           encryptDB: encryptDB,
-                                          isUpdated: true,
-                                          loading: false,
                                       })
                                   })
                     })

--- a/src/components/dataSet-settings.js
+++ b/src/components/dataSet-settings.js
@@ -9,6 +9,7 @@ import {
     DataSetSettingsDefault,
 } from '../constants/data-set-settings'
 import GlobalSpecificSettings from '../pages/global-specific-settings'
+import { NAMESPACE, DATASET_SETTINGS } from '../constants/data-store'
 import { getInstance } from 'd2'
 
 const dataSetSettings = DataSetting
@@ -110,24 +111,16 @@ class DataSetSettings extends React.Component {
      * @param data (object data)
      */
     saveDataApi = (settingType, data) => {
-        if (this.keyName === 'dataSet_settings') {
+        if (this.keyName === DATASET_SETTINGS) {
             if (Object.keys(this[settingType]).length) {
                 data[settingType] = this[settingType]
             }
 
-            api.updateValue(
-                'ANDROID_SETTING_APP',
-                'dataSet_settings',
-                data
-            ).then(res => res)
+            api.updateValue(NAMESPACE, DATASET_SETTINGS, data).then(res => res)
         } else {
-            api.getKeys('ANDROID_SETTING_APP').then(
+            api.getKeys(NAMESPACE).then(
                 api
-                    .createValue(
-                        'ANDROID_SETTING_APP',
-                        'dataSet_settings',
-                        data
-                    )
+                    .createValue(NAMESPACE, DATASET_SETTINGS, data)
                     .then(data => data)
             )
         }
@@ -234,11 +227,10 @@ class DataSetSettings extends React.Component {
                     .periodDSDBTrimming,
             }
 
-            const sumaryString = this.state.specificSetting.periodDSDownload
             const sumarySettings =
                 this.state.specificSetting.periodDSDownload === undefined
                     ? undefined
-                    : this.arrangeWord(sumaryString)
+                    : this.state.specificSetting.periodDSDownload
             const newDataSetRow = {
                 name: dataSetNameFilter[0].name,
                 sumarySettings: sumarySettings,
@@ -335,19 +327,17 @@ class DataSetSettings extends React.Component {
         await api
             .getNamespaces()
             .then(res => {
-                const nameSpace = res.filter(
-                    name => name === 'ANDROID_SETTING_APP'
-                )
+                const nameSpace = res.filter(name => name === NAMESPACE)
                 nameSpace.length === 0
                     ? (this.nameSpace = undefined)
                     : (this.nameSpace = nameSpace[0])
                 this.nameSpace !== undefined
                     ? this.setState({ isUpdated: true })
                     : this.setState({ isUpdated: false })
-                if (this.nameSpace === 'ANDROID_SETTING_APP') {
+                if (this.nameSpace === NAMESPACE) {
                     api.getKeys(this.nameSpace).then(res => {
                         const keyName = res.filter(
-                            name => name === 'dataSet_settings'
+                            name => name === DATASET_SETTINGS
                         )
                         keyName.length === 0
                             ? (this.keyName = undefined)
@@ -370,15 +360,12 @@ class DataSetSettings extends React.Component {
                                             ) {
                                                 const dataSet = this
                                                     .specificSettings[key]
-                                                const sumaryString =
-                                                    dataSet.periodDSDownload
                                                 const sumarySettings =
                                                     dataSet.periodDSDownload ===
                                                     undefined
                                                         ? undefined
-                                                        : this.arrangeWord(
-                                                              sumaryString
-                                                          )
+                                                        : dataSet.periodDSDownload
+
                                                 const newDataSetRow = {
                                                     name: dataSet.name,
                                                     sumarySettings: sumarySettings,
@@ -424,8 +411,8 @@ class DataSetSettings extends React.Component {
 
                             this.saveDataApi('specificSettings', data)
 
-                            this.nameSpace = 'ANDROID_SETTING_APP'
-                            this.keyName = 'dataSet_settings'
+                            this.nameSpace = NAMESPACE
+                            this.keyName = DATASET_SETTINGS
 
                             this.setState({
                                 isUpdated: true,
@@ -434,10 +421,9 @@ class DataSetSettings extends React.Component {
                         }
                     })
                 } else if (this.nameSpace === undefined) {
-                    api.createNamespace(
-                        'ANDROID_SETTING_APP',
-                        'dataSet_settings'
-                    ).catch(e => console.error(e))
+                    api.createNamespace(NAMESPACE, DATASET_SETTINGS).catch(e =>
+                        console.error(e)
+                    )
                 }
             })
             .catch(e => {

--- a/src/components/dataSet-settings.js
+++ b/src/components/dataSet-settings.js
@@ -227,10 +227,11 @@ class DataSetSettings extends React.Component {
                     .periodDSDBTrimming,
             }
 
+            const sumaryString = this.state.specificSetting.periodDSDownload
             const sumarySettings =
                 this.state.specificSetting.periodDSDownload === undefined
                     ? undefined
-                    : this.state.specificSetting.periodDSDownload
+                    : this.arrangeWord(sumaryString)
             const newDataSetRow = {
                 name: dataSetNameFilter[0].name,
                 sumarySettings: sumarySettings,
@@ -360,11 +361,15 @@ class DataSetSettings extends React.Component {
                                             ) {
                                                 const dataSet = this
                                                     .specificSettings[key]
+                                                const sumaryString =
+                                                    dataSet.periodDSDownload
                                                 const sumarySettings =
                                                     dataSet.periodDSDownload ===
                                                     undefined
                                                         ? undefined
-                                                        : dataSet.periodDSDownload
+                                                        : this.arrangeWord(
+                                                              sumaryString
+                                                          )
 
                                                 const newDataSetRow = {
                                                     name: dataSet.name,

--- a/src/components/program-settings.js
+++ b/src/components/program-settings.js
@@ -9,6 +9,7 @@ import {
     ProgramSettingsDefault,
     maxValues,
 } from '../constants/program-settings'
+import { NAMESPACE, PROGRAM_SETTINGS } from '../constants/data-store'
 
 import GlobalSpecificSettings from '../pages/global-specific-settings'
 import { getInstance } from 'd2'
@@ -233,24 +234,16 @@ class ProgramSettings extends React.Component {
     }
 
     saveDataApi = (settingType, data) => {
-        if (this.keyName === 'program_settings') {
+        if (this.keyName === PROGRAM_SETTINGS) {
             if (Object.keys(this[settingType]).length) {
                 data[settingType] = this[settingType]
             }
 
-            api.updateValue(
-                'ANDROID_SETTING_APP',
-                'program_settings',
-                data
-            ).then(res => res)
+            api.updateValue(NAMESPACE, PROGRAM_SETTINGS, data).then(res => res)
         } else {
-            api.getKeys('ANDROID_SETTING_APP').then(
+            api.getKeys(NAMESPACE).then(
                 api
-                    .createValue(
-                        'ANDROID_SETTING_APP',
-                        'program_settings',
-                        data
-                    )
+                    .createValue(NAMESPACE, PROGRAM_SETTINGS, data)
                     .then(data => data)
             )
         }
@@ -530,19 +523,17 @@ class ProgramSettings extends React.Component {
         await api
             .getNamespaces()
             .then(res => {
-                const nameSpace = res.filter(
-                    name => name === 'ANDROID_SETTING_APP'
-                )
+                const nameSpace = res.filter(name => name === NAMESPACE)
                 nameSpace.length === 0
                     ? (this.nameSpace = undefined)
                     : (this.nameSpace = nameSpace[0])
                 this.nameSpace !== undefined
                     ? this.setState({ isUpdated: true })
                     : this.setState({ isUpdated: false })
-                if (this.nameSpace === 'ANDROID_SETTING_APP') {
+                if (this.nameSpace === NAMESPACE) {
                     api.getKeys(this.nameSpace).then(res => {
                         const keyName = res.filter(
-                            name => name === 'program_settings'
+                            name => name === PROGRAM_SETTINGS
                         )
                         keyName.length === 0
                             ? (this.keyName = undefined)
@@ -668,8 +659,8 @@ class ProgramSettings extends React.Component {
 
                             this.saveDataApi('specificSettings', data)
 
-                            this.nameSpace = 'ANDROID_SETTING_APP'
-                            this.keyName = 'program_settings'
+                            this.nameSpace = NAMESPACE
+                            this.keyName = PROGRAM_SETTINGS
 
                             this.setState({
                                 isUpdated: true,
@@ -678,10 +669,9 @@ class ProgramSettings extends React.Component {
                         }
                     })
                 } else if (this.nameSpace === undefined) {
-                    api.createNamespace(
-                        'ANDROID_SETTING_APP',
-                        'program_settings'
-                    ).catch(e => console.error(e))
+                    api.createNamespace(NAMESPACE, PROGRAM_SETTINGS).catch(e =>
+                        console.error(e)
+                    )
                 }
             })
             .catch(e => {

--- a/src/components/test-android-container.js
+++ b/src/components/test-android-container.js
@@ -8,6 +8,7 @@ import {
 } from '../constants/test-android'
 import TestAndroid from './test-android'
 import { memorySizeOf, formatByteSize } from '../utils/memory-size'
+import { NAMESPACE, PROGRAM_SETTINGS } from '../constants/data-store'
 
 import api from '../utils/api'
 
@@ -1112,7 +1113,7 @@ class TestAndroidContainer extends React.Component {
                 })
             })
 
-        api.getValue('ANDROID_SETTING_APP', 'program_settings')
+        api.getValue(NAMESPACE, PROGRAM_SETTINGS)
             .then(res => {
                 this.globalSettings = res.value.globalSettings
                 this.specificSettings = res.value.specificSettings

--- a/src/constants/data-store.js
+++ b/src/constants/data-store.js
@@ -1,0 +1,4 @@
+export const NAMESPACE = 'ANDROID_SETTING_APP'
+export const GENERAL_SETTINGS = 'general_settings'
+export const PROGRAM_SETTINGS = 'program_settings'
+export const DATASET_SETTINGS = 'dataSet_settings'


### PR DESCRIPTION
Here I changed the namespaces and keynames that we use in Datastore, instead of using the DataStore API with strings I changed to constants. Also, changed `android_settings` keynames to `general_settings`.