### PR TITLE
fix: change metadata and data sync constant

### DIFF
--- a/src/constants/android-settings.js
+++ b/src/constants/android-settings.js
@@ -1,15 +1,11 @@
 export const metadataOptions = [
     {
-        value: '1h',
-        label: '1h',
-    },
-    {
         value: '12h',
         label: '12h',
     },
     {
-        value: '1d',
-        label: '1d',
+        value: '24h',
+        label: '24h',
     },
     {
         value: '7d',
@@ -19,8 +15,8 @@ export const metadataOptions = [
 
 export const dataOptions = [
     {
-        value: '30m',
-        label: '30m',
+        value: '15m',
+        label: '15m',
     },
     {
         value: '1h',
@@ -45,7 +41,7 @@ export const maxValues = {
 }
 
 export const androidSettingsDefault = {
-    metadataSync: '1d',
+    metadataSync: '24h',
     dataSync: '24h',
     numberSmsToSend: '',
     numberSmsConfirmation: '',

--- a/src/constants/android-settings.js
+++ b/src/constants/android-settings.js
@@ -1,9 +1,5 @@
 export const metadataOptions = [
     {
-        value: '12h',
-        label: '12h',
-    },
-    {
         value: '24h',
         label: '24h',
     },
@@ -15,8 +11,8 @@ export const metadataOptions = [
 
 export const dataOptions = [
     {
-        value: '15m',
-        label: '15m',
+        value: '30m',
+        label: '30m',
     },
     {
         value: '1h',


### PR DESCRIPTION
This PR has:

General settings constants:
- `metadataSync`: remove option 1h and 12h