### PR TITLE
Feat/dataset period type

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-03-05T19:05:24.542Z\n"
-"PO-Revision-Date: 2020-03-05T19:05:24.542Z\n"
+"POT-Creation-Date: 2020-03-11T16:30:04.435Z\n"
+"PO-Revision-Date: 2020-03-11T16:30:04.435Z\n"
 
 msgid "Metadata Sync"
 msgstr ""
@@ -71,18 +71,6 @@ msgstr ""
 msgid "Number of Periods"
 msgstr ""
 
-msgid "Any"
-msgstr ""
-
-msgid "Last month"
-msgstr ""
-
-msgid "Last 3 months"
-msgstr ""
-
-msgid "Last 12 months"
-msgstr ""
-
 msgid "General Settings"
 msgstr ""
 
@@ -122,16 +110,25 @@ msgstr ""
 msgid "TEI Enrollment date"
 msgstr ""
 
-msgid "TEI last update"
+msgid "Any"
 msgstr ""
 
-msgid "TE reserved values"
+msgid "Last month"
+msgstr ""
+
+msgid "Last 3 months"
+msgstr ""
+
+msgid "Last 12 months"
+msgstr ""
+
+msgid "TEI last update"
 msgstr ""
 
 msgid "Events"
 msgstr ""
 
-msgid "Event period"
+msgid "Event date"
 msgstr ""
 
 msgid "All Org Units"

--- a/src/components/android-settings-container.js
+++ b/src/components/android-settings-container.js
@@ -47,11 +47,11 @@ class AndroidSettingsContainer extends React.Component {
         e.preventDefault()
 
         let { value } = e.target
-        
+
         if (e.target.name === 'reservedValues') {
             value = Math.min(maxValues.reservedValues, parseInt(value))
         }
-      
+
         if (e.target.name === 'encryptDB') {
             value = e.target.checked
         }
@@ -172,9 +172,9 @@ class AndroidSettingsContainer extends React.Component {
                                       dataSync: dataSync,
                                       numberSmsToSend: '',
                                       numberSmsConfirmation: '',
-                                      reservedValues: reservedValues,,
+                                      reservedValues: reservedValues,
                                       encryptDB: encryptDB,
-                                  })          
+                                  })
                                   .then(res => {
                                       this.setState({
                                           metadataSync: metadataSync,

--- a/src/components/dataSet-settings.js
+++ b/src/components/dataSet-settings.js
@@ -448,7 +448,7 @@ class DataSetSettings extends React.Component {
                 .list({
                     paging: false,
                     level: 1,
-                    fields: 'id,name',
+                    fields: 'id,name,periodType',
                     filter: 'access.data.write:eq:true',
                 })
                 .then(collection => {
@@ -492,6 +492,7 @@ class DataSetSettings extends React.Component {
                 specificSettingData={dataSpecificSetting}
                 specificSettingHandleSubmit={this.handleSubmitDialog}
                 specificSetting={this.state.specificSetting}
+                completeListOptions={this.dataSetListComplete}
             />
         )
     }

--- a/src/components/dialog-table.js
+++ b/src/components/dialog-table.js
@@ -9,6 +9,7 @@ import MenuItem from '@material-ui/core/MenuItem'
 import { Button } from '@dhis2/ui-core'
 
 import ProgramTable from './program-table'
+import DataSetTable from './settings-table/dataset-table'
 import i18n from '@dhis2/d2-i18n'
 import titleStyles from '../styles/LayoutTitles.module.css'
 import buttonStyles from '../styles/Button.module.css'
@@ -56,11 +57,27 @@ class DialogTable extends React.Component {
                         </p>
                     )}
 
-                    <ProgramTable
-                        data={this.props.data}
-                        states={this.props.specificSetting}
-                        onChange={this.props.handleChange}
-                    />
+                    {this.props.title === 'Programs' ? (
+                        <ProgramTable
+                            data={this.props.data}
+                            states={this.props.specificSetting}
+                            onChange={this.props.handleChange}
+                            programTitle={this.props.dataTitle}
+                            programOptions={this.props.dataTitleOptions}
+                            programSelected={this.props.titleValue}
+                            completeListOptions={this.props.completeListOptions}
+                        />
+                    ) : (
+                        <DataSetTable
+                            data={this.props.data}
+                            states={this.props.specificSetting}
+                            onChange={this.props.handleChange}
+                            dataSetTitle={this.props.dataTitle}
+                            dataSetOptions={this.props.dataTitleOptions}
+                            dataSetSelected={this.props.titleValue}
+                            completeListOptions={this.props.completeListOptions}
+                        />
+                    )}
                 </DialogContent>
                 <DialogActions>
                     <Button

--- a/src/components/settings-table/dataset-table-row.js
+++ b/src/components/settings-table/dataset-table-row.js
@@ -1,0 +1,39 @@
+import React from 'react'
+
+import TableRow from '@material-ui/core/TableRow'
+import TableCell from '@material-ui/core/TableCell'
+import InputNumber from '../input-number'
+import dataTableStyles from '../../styles/DataTable.module.css'
+
+const DataSetTableRow = ({
+    dataRow,
+    periodType,
+    defaultValue,
+    states,
+    onChange,
+}) => {
+    return (
+        <TableRow>
+            <TableCell
+                component="th"
+                scope="row"
+                className={dataTableStyles.dataTable__rows__row__column}
+            >
+                {dataRow.option} ({periodType})
+            </TableCell>
+            <TableCell
+                className={dataTableStyles.dataTable__rows__row__column}
+                align="right"
+            >
+                <InputNumber
+                    name={dataRow.keyDownload}
+                    max={dataRow.maxValue}
+                    value={states[dataRow.keyDownload]}
+                    onChange={onChange}
+                />
+            </TableCell>
+        </TableRow>
+    )
+}
+
+export default DataSetTableRow

--- a/src/components/settings-table/dataset-table.js
+++ b/src/components/settings-table/dataset-table.js
@@ -1,0 +1,127 @@
+import React from 'react'
+
+import Table from '@material-ui/core/Table'
+import TableBody from '@material-ui/core/TableBody'
+import TableCell from '@material-ui/core/TableCell'
+import TableHead from '@material-ui/core/TableHead'
+import TableRow from '@material-ui/core/TableRow'
+import DataSetTableRow from './dataset-table-row'
+
+import i18n from '@dhis2/d2-i18n'
+import dataTableStyles from '../../styles/DataTable.module.css'
+import { periodTypeConstants } from '../../constants/data-set-settings'
+
+class DataSetTable extends React.Component {
+    constructor(props) {
+        super(props)
+
+        this.state = {
+            dataSetSelected: this.props.dataSetSelected,
+            dataSetFilter: '',
+            periodType: '',
+            defaultValue: '',
+            selected: false,
+        }
+    }
+
+    checkPeriodType = () => {
+        if (this.props.dataSetSelected !== '') {
+            const dataSetSelected = this.props.completeListOptions.filter(
+                dataSet => dataSet.id === this.props.dataSetSelected
+            )
+            this.dataSetFilter = dataSetSelected[0]
+
+            this.props.states.periodDSDownload =
+                periodTypeConstants[dataSetSelected[0].periodType].default
+
+            this.setState({
+                dataSetSelected: this.props.dataSetSelected,
+                dataSetFilter: dataSetSelected,
+                periodType: this.dataSetFilter.periodType,
+                defaultValue:
+                    periodTypeConstants[dataSetSelected[0].periodType].default,
+                selected: true,
+            })
+        }
+    }
+
+    checkPeriodTypeEdit = () => {
+        if (this.props.dataSetSelected !== '') {
+            const dataSetSelected = this.props.completeListOptions.filter(
+                dataSet => dataSet.id === this.props.dataSetSelected
+            )
+            this.dataSetFilter = dataSetSelected[0]
+
+            this.setState({
+                dataSetSelected: this.props.dataSetSelected,
+                dataSetFilter: dataSetSelected,
+                periodType: this.dataSetFilter.periodType,
+                defaultValue:
+                    periodTypeConstants[dataSetSelected[0].periodType].default,
+                selected: true,
+            })
+        }
+    }
+
+    componentDidUpdate() {
+        if (this.props.dataSetSelected !== '') {
+            if (!this.state.dataSetSelected) {
+                this.checkPeriodType()
+            } else if (
+                this.state.dataSetSelected !== this.props.dataSetSelected
+            ) {
+                this.checkPeriodType()
+            } else if (!this.state.periodType) {
+                this.checkPeriodTypeEdit()
+            }
+        }
+    }
+
+    render() {
+        if (this.props.dataSetSelected === '') {
+            return null
+        }
+
+        if (this.state.dataSetSelected || this.state.periodType) {
+            return (
+                <Table className={dataTableStyles.dataTable}>
+                    <TableHead>
+                        <TableRow>
+                            <TableCell
+                                className={
+                                    dataTableStyles.dataTable__headers__header
+                                }
+                            >
+                                {' '}
+                            </TableCell>
+                            <TableCell
+                                className={
+                                    dataTableStyles.dataTable__headers__header
+                                }
+                                align="right"
+                            >
+                                {i18n.t('Download')}
+                            </TableCell>
+                        </TableRow>
+                    </TableHead>
+                    <TableBody>
+                        {this.props.data.map(row => (
+                            <DataSetTableRow
+                                key={row.option}
+                                dataRow={row}
+                                periodType={this.state.periodType}
+                                defaultValue={this.state.defaultValue}
+                                states={this.props.states}
+                                onChange={this.props.onChange}
+                            />
+                        ))}
+                    </TableBody>
+                </Table>
+            )
+        }
+
+        return null
+    }
+}
+
+export default DataSetTable

--- a/src/constants/data-set-settings.js
+++ b/src/constants/data-set-settings.js
@@ -20,3 +20,78 @@ export const DataSetSettingsDefault = {
     periodDSDownload: 12,
     periodDSDBTrimming: 12,
 }
+
+export const periodTypeConstants = {
+    Daily: {
+        type: 'Daily',
+        default: 59,
+    },
+    Weekly: {
+        type: 'Weekly',
+        default: 12,
+    },
+    WeeklyWednesday: {
+        type: 'WeeklyWednesday',
+        default: 12,
+    },
+    WeeklyThursday: {
+        type: 'WeeklyThursday',
+        default: 12,
+    },
+    WeeklySaturday: {
+        type: 'WeeklySaturday',
+        default: 12,
+    },
+    WeeklySunday: {
+        type: 'WeeklySunday',
+        default: 12,
+    },
+    BiWeekly: {
+        type: 'BiWeekly',
+        default: 12,
+    },
+    Monthly: {
+        type: 'Monthly',
+        default: 11,
+    },
+    BiMonthly: {
+        type: 'BiMonthly',
+        default: 5,
+    },
+    Quarterly: {
+        type: 'Quarterly',
+        default: 4,
+    },
+    SixMonthly: {
+        type: 'SixMonthly',
+        default: 4,
+    },
+    SixMonthlyApril: {
+        type: 'SixMonthlyApril',
+        default: 4,
+    },
+    SixMonthlyNov: {
+        type: 'SixMonthlyNov',
+        default: 4,
+    },
+    Yearly: {
+        type: 'Yearly',
+        default: 4,
+    },
+    FinancialApril: {
+        type: 'FinancialApril',
+        default: 4,
+    },
+    FinancialJuly: {
+        type: 'FinancialJuly',
+        default: 4,
+    },
+    FinancialOct: {
+        type: 'FinancialOct',
+        default: 4,
+    },
+    FinancialNov: {
+        type: 'FinancialNov',
+        default: 4,
+    },
+}

--- a/src/constants/data-set-settings.js
+++ b/src/constants/data-set-settings.js
@@ -17,8 +17,8 @@ export const DataSpecificSetting = [
 ]
 
 export const DataSetSettingsDefault = {
-    periodDSDownload: 12,
-    periodDSDBTrimming: 12,
+    periodDSDownload: 11,
+    periodDSDBTrimming: 11,
 }
 
 export const periodTypeConstants = {

--- a/src/pages/global-specific-settings.js
+++ b/src/pages/global-specific-settings.js
@@ -120,6 +120,7 @@ class GlobalSpecificSettings extends React.Component {
                             this.props.specificSettingHandleSubmit
                         }
                         specificSetting={this.props.specificSetting}
+                        completeListOptions={this.props.completeListOptions}
                     />
                 </div>
             </React.Fragment>


### PR DESCRIPTION
This PR has:

Before show specific settings options user should select a dataset, then the app will check `periodType` property, every periodType has a default number of periods that should appear as a default value for input number. 

Changes in: 
- dataset_settings constants (periodTypeConstants)
- dataset-table and dataset-table-row (component) adding new components
- dialog-table it will probably show conflict because #20 also adds a `completeListOptions`
- global-specific-settings it will probably show conflic because #20 also adds a ProgramTable (that was created for programType) also change ProgramTable to SettingsTable (component for global settings)