### PR TITLE
Fix/program settings for

### DIFF
--- a/src/components/program-settings.js
+++ b/src/components/program-settings.js
@@ -409,6 +409,7 @@ class ProgramSettings extends React.Component {
     }
 
     handleReset = () => {
+        programData = GlobalProgramSpecial
         this.setState({
             settingDownload: settingDownload,
             settingDBTrimming: settingDBTrimming,

--- a/src/components/program-settings.js
+++ b/src/components/program-settings.js
@@ -9,6 +9,8 @@ import {
     SpecificProgram,
     ProgramSettingsDefault,
     maxValues,
+    GLOBAL,
+    PER_ORG_UNIT,
 } from '../constants/program-settings'
 import { NAMESPACE, PROGRAM_SETTINGS } from '../constants/data-store'
 
@@ -157,10 +159,7 @@ class ProgramSettings extends React.Component {
         e.preventDefault()
 
         if (e.target.name === 'settingDownload') {
-            if (
-                e.target.value === 'GLOBAL' ||
-                e.target.value === 'PER_ORG_UNIT'
-            ) {
+            if (e.target.value === GLOBAL || e.target.value === PER_ORG_UNIT) {
                 programData = GlobalProgramSpecial
             } else {
                 programData = GlobalProgram
@@ -213,8 +212,8 @@ class ProgramSettings extends React.Component {
         let globalSettings
 
         if (
-            this.state.settingDownload == 'GLOBAL' ||
-            this.state.settingDownload == 'PER_ORG_UNIT'
+            this.state.settingDownload == GLOBAL ||
+            this.state.settingDownload == PER_ORG_UNIT
         ) {
             globalSettings = {
                 lastUpdated: new Date().toJSON(),
@@ -577,10 +576,9 @@ class ProgramSettings extends React.Component {
 
                                         if (
                                             this.globalSettings
-                                                .settingDownload == 'GLOBAL' ||
+                                                .settingDownload == GLOBAL ||
                                             this.globalSettings
-                                                .settingDownload ==
-                                                'PER_ORG_UNIT'
+                                                .settingDownload == PER_ORG_UNIT
                                         ) {
                                             programData = GlobalProgramSpecial
                                         } else {

--- a/src/components/program-settings.js
+++ b/src/components/program-settings.js
@@ -4,7 +4,8 @@ import { CircularLoader } from '@dhis2/ui-core'
 import api from '../utils/api'
 
 import {
-    Program,
+    GlobalProgram,
+    GlobalProgramSpecial,
     SpecificProgram,
     ProgramSettingsDefault,
     maxValues,
@@ -14,7 +15,7 @@ import { NAMESPACE, PROGRAM_SETTINGS } from '../constants/data-store'
 import GlobalSpecificSettings from '../pages/global-specific-settings'
 import { getInstance } from 'd2'
 
-const programData = Program
+let programData = GlobalProgram
 const specificProgramData = SpecificProgram
 const {
     settingDownload,
@@ -154,6 +155,18 @@ class ProgramSettings extends React.Component {
 
     handleChange = e => {
         e.preventDefault()
+
+        if (e.target.name === 'settingDownload') {
+            if (
+                e.target.value === 'GLOBAL' ||
+                e.target.value === 'PER_ORG_UNIT'
+            ) {
+                programData = GlobalProgramSpecial
+            } else {
+                programData = GlobalProgram
+            }
+        }
+
         this.setState({
             ...this.state,
             [e.target.name]: this.chooseSetting(e.target.name, e.target.value),
@@ -196,22 +209,44 @@ class ProgramSettings extends React.Component {
         if (!this.updateGlobal) {
             return true
         }
-        const globalSettings = {
-            lastUpdated: new Date().toJSON(),
-            settingDownload: this.state.settingDownload,
-            settingDBTrimming: this.state.settingDBTrimming,
-            teiDownload: this.state.teiDownload,
-            teiDBTrimming: this.state.teiDBTrimming,
-            enrollmentDownload: this.state.enrollmentDownload,
-            enrollmentDBTrimming: this.state.enrollmentDBTrimming,
-            enrollmentDateDownload: this.state.enrollmentDateDownload,
-            enrollmentDateDBTrimming: this.state.enrollmentDateDBTrimming,
-            updateDownload: this.state.updateDownload,
-            updateDBTrimming: this.state.updateDBTrimming,
-            eventsDownload: this.state.eventsDownload,
-            eventsDBTrimming: this.state.eventsDBTrimming,
-            eventDateDownload: this.state.eventDateDownload,
-            eventDateDBTrimming: this.state.eventDateDBTrimming,
+
+        let globalSettings
+
+        if (
+            this.state.settingDownload == 'GLOBAL' ||
+            this.state.settingDownload == 'PER_ORG_UNIT'
+        ) {
+            globalSettings = {
+                lastUpdated: new Date().toJSON(),
+                settingDownload: this.state.settingDownload,
+                settingDBTrimming: this.state.settingDBTrimming,
+                teiDownload: this.state.teiDownload,
+                teiDBTrimming: this.state.teiDBTrimming,
+                updateDownload: this.state.updateDownload,
+                updateDBTrimming: this.state.updateDBTrimming,
+                eventsDownload: this.state.eventsDownload,
+                eventsDBTrimming: this.state.eventsDBTrimming,
+                eventDateDownload: this.state.eventDateDownload,
+                eventDateDBTrimming: this.state.eventDateDBTrimming,
+            }
+        } else {
+            globalSettings = {
+                lastUpdated: new Date().toJSON(),
+                settingDownload: this.state.settingDownload,
+                settingDBTrimming: this.state.settingDBTrimming,
+                teiDownload: this.state.teiDownload,
+                teiDBTrimming: this.state.teiDBTrimming,
+                enrollmentDownload: this.state.enrollmentDownload,
+                enrollmentDBTrimming: this.state.enrollmentDBTrimming,
+                enrollmentDateDownload: this.state.enrollmentDateDownload,
+                enrollmentDateDBTrimming: this.state.enrollmentDateDBTrimming,
+                updateDownload: this.state.updateDownload,
+                updateDBTrimming: this.state.updateDBTrimming,
+                eventsDownload: this.state.eventsDownload,
+                eventsDBTrimming: this.state.eventsDBTrimming,
+                eventDateDownload: this.state.eventDateDownload,
+                eventDateDBTrimming: this.state.eventDateDBTrimming,
+            }
         }
 
         this.globalSettings = globalSettings
@@ -537,13 +572,26 @@ class ProgramSettings extends React.Component {
                                     }
 
                                     if (res.value.globalSettings) {
+                                        this.globalSettings =
+                                            res.value.globalSettings
+
+                                        if (
+                                            this.globalSettings
+                                                .settingDownload == 'GLOBAL' ||
+                                            this.globalSettings
+                                                .settingDownload ==
+                                                'PER_ORG_UNIT'
+                                        ) {
+                                            programData = GlobalProgramSpecial
+                                        } else {
+                                            programData = GlobalProgram
+                                        }
+
                                         this.setState({
                                             ...res.value.globalSettings,
                                             isUpdated: true,
                                             loading: false,
                                         })
-                                        this.globalSettings =
-                                            res.value.globalSettings
                                     }
                                 }
                             )

--- a/src/constants/program-settings.js
+++ b/src/constants/program-settings.js
@@ -1,6 +1,6 @@
 import i18n from '@dhis2/d2-i18n'
 
-export const Program = [
+export const GlobalProgram = [
     {
         keyDownload: 'settingDownload',
         keyDBTrimming: 'settingDBTrimming',
@@ -113,6 +113,144 @@ export const Program = [
                 value: 'LAST_12_MONTHS',
             },
         ],
+    },
+    {
+        keyDownload: 'updateDownload',
+        keyDBTrimming: 'updateDBTrimming',
+        option: i18n.t('TEI last update'),
+        download: [
+            {
+                label: i18n.t('Any'),
+                value: 'ANY',
+            },
+            {
+                label: i18n.t('Last month'),
+                value: 'LAST_MONTH',
+            },
+            {
+                label: i18n.t('Last 3 months'),
+                value: 'LAST_3_MONTHS',
+            },
+            {
+                label: i18n.t('Last 12 months'),
+                value: 'LAST_12_MONTHS',
+            },
+        ],
+        DBTrimming: [
+            {
+                label: i18n.t('Any'),
+                value: 'ANY',
+            },
+            {
+                label: i18n.t('Last month'),
+                value: 'LAST_MONTH',
+            },
+            {
+                label: i18n.t('Last 3 months'),
+                value: 'LAST_3_MONTHS',
+            },
+            {
+                label: i18n.t('Last 12 months'),
+                value: 'LAST_12_MONTHS',
+            },
+        ],
+    },
+    {
+        option: i18n.t('Events'),
+        keyDownload: 'eventsDownload',
+        keyDBTrimming: 'eventsDBTrimming',
+        maxValue: 3000,
+    },
+    {
+        keyDownload: 'eventDateDownload',
+        keyDBTrimming: 'eventDateDBTrimming',
+        option: i18n.t('Event date'),
+        download: [
+            {
+                label: i18n.t('Any'),
+                value: 'ANY',
+            },
+            {
+                label: i18n.t('Last month'),
+                value: 'LAST_MONTH',
+            },
+            {
+                label: i18n.t('Last 3 months'),
+                value: 'LAST_3_MONTHS',
+            },
+            {
+                label: i18n.t('Last 12 months'),
+                value: 'LAST_12_MONTHS',
+            },
+        ],
+        DBTrimming: [
+            {
+                label: i18n.t('Any'),
+                value: 'ANY',
+            },
+            {
+                label: i18n.t('Last month'),
+                value: 'LAST_MONTH',
+            },
+            {
+                label: i18n.t('Last 3 months'),
+                value: 'LAST_3_MONTHS',
+            },
+            {
+                label: i18n.t('Last 12 months'),
+                value: 'LAST_12_MONTHS',
+            },
+        ],
+    },
+]
+
+export const GlobalProgramSpecial = [
+    {
+        keyDownload: 'settingDownload',
+        keyDBTrimming: 'settingDBTrimming',
+        option: i18n.t('Setting for'),
+        download: [
+            {
+                label: i18n.t('Global'),
+                value: 'GLOBAL',
+            },
+            {
+                label: i18n.t('Per Org Unit'),
+                value: 'PER_ORG_UNIT',
+            },
+            {
+                label: i18n.t('Per program'),
+                value: 'PER_PROGRAM',
+            },
+            {
+                label: i18n.t('Per OU and program'),
+                value: 'PER_OU_AND_PROGRAM',
+            },
+        ],
+        DBTrimming: [
+            {
+                label: i18n.t('Global'),
+                value: 'GLOBAL',
+            },
+            {
+                label: i18n.t('Per Org Unit'),
+                value: 'PER_ORG_UNIT',
+            },
+            {
+                label: i18n.t('Per program'),
+                value: 'PER_PROGRAM',
+            },
+            {
+                label: i18n.t('Per OU and program'),
+                value: 'PER_OU_AND_PROGRAM',
+            },
+        ],
+    },
+    {
+        keyDownload: 'teiDownload',
+        keyDBTrimming: 'teiDBTrimming',
+        option: i18n.t('TEIs'),
+        maxValue: 2000,
     },
     {
         keyDownload: 'updateDownload',

--- a/src/constants/program-settings.js
+++ b/src/constants/program-settings.js
@@ -553,3 +553,6 @@ export const ProgramSettingsDefault = {
     eventDateDownload: 'ANY',
     eventDateDBTrimming: 'ANY',
 }
+
+export const GLOBAL = 'GLOBAL'
+export const PER_ORG_UNIT = 'PER_ORG_UNIT'


### PR DESCRIPTION
This PR has:

Program Global Settings, in case `settingDownload` is:

- **GLOBAL** or **PER_ORG_UNIT** should only show: `settingDownload`, `teiDownload`, `updateDownload`, `eventsDownload`, `eventDateDownload`.
- **PER_PROGRAM** or **PER_OU_AND_PROGRAM** should show all options and settings.

Changes in:

- program_settings constants
- program_settings (component) will probably show conflict because PRs #20 #19 also have changes related to program_setting input handleChange.