### PR TITLE
fix: double click for change encryptDB state

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-03-05T19:05:24.542Z\n"
-"PO-Revision-Date: 2020-03-05T19:05:24.542Z\n"
+"POT-Creation-Date: 2020-03-19T19:12:24.698Z\n"
+"PO-Revision-Date: 2020-03-19T19:12:24.698Z\n"
 
 msgid "Metadata Sync"
 msgstr ""
@@ -36,6 +36,17 @@ msgid "Delete"
 msgstr ""
 
 msgid "Cancel"
+msgstr ""
+
+msgid "{{encrypt}} DB"
+msgstr ""
+
+msgid ""
+"{{encrypt}} data base is a critical action that could have very serious "
+"consequences. Are you sure you want to {{encrypt}} DB?"
+msgstr ""
+
+msgid "Decrypt DB"
 msgstr ""
 
 msgid "Values per"
@@ -68,19 +79,13 @@ msgstr ""
 msgid "RUN TEST"
 msgstr ""
 
+msgid "Encrypt"
+msgstr ""
+
+msgid "Decrypt"
+msgstr ""
+
 msgid "Number of Periods"
-msgstr ""
-
-msgid "Any"
-msgstr ""
-
-msgid "Last month"
-msgstr ""
-
-msgid "Last 3 months"
-msgstr ""
-
-msgid "Last 12 months"
 msgstr ""
 
 msgid "General Settings"
@@ -122,16 +127,25 @@ msgstr ""
 msgid "TEI Enrollment date"
 msgstr ""
 
-msgid "TEI last update"
+msgid "Any"
 msgstr ""
 
-msgid "TE reserved values"
+msgid "Last month"
+msgstr ""
+
+msgid "Last 3 months"
+msgstr ""
+
+msgid "Last 12 months"
+msgstr ""
+
+msgid "TEI last update"
 msgstr ""
 
 msgid "Events"
 msgstr ""
 
-msgid "Event period"
+msgid "Event date"
 msgstr ""
 
 msgid "All Org Units"

--- a/src/components/android-settings-container.js
+++ b/src/components/android-settings-container.js
@@ -38,6 +38,7 @@ class AndroidSettingsContainer extends React.Component {
         isUpdated: false,
         loading: true,
         errorConfirmation: false,
+        openDialog: false,
     }
 
     /**
@@ -59,10 +60,36 @@ class AndroidSettingsContainer extends React.Component {
         this.updateGlobal = true
     }
 
-    handleChangeSwitch = e => {
+    /**
+     * When Switch is click open Dialog alert
+     */
+    handleChangeSwitch = () => {
         this.setState({
             ...this.state,
-            [e.target.name]: e.target.checked,
+            openDialog: true,
+        })
+        this.updateGlobal = true
+    }
+
+    /**
+     * Close Dialog alert
+     */
+    handleCloseDialog = () => {
+        this.setState({
+            ...this.state,
+            openDialog: false,
+        })
+        this.updateGlobal = true
+    }
+
+    /**
+     * Handle EncryptDB switch state and close dialog
+     */
+    handleEncryptSwitch = isChecked => {
+        this.setState({
+            ...this.state,
+            encryptDB: !isChecked,
+            openDialog: false,
         })
         this.updateGlobal = true
     }
@@ -136,6 +163,7 @@ class AndroidSettingsContainer extends React.Component {
             reservedValues: reservedValues,
             encryptDB: encryptDB,
             isUpdated: false,
+            openDialog: false,
         })
         this.updateGlobal = true
     }
@@ -241,6 +269,8 @@ class AndroidSettingsContainer extends React.Component {
                 handleReset={this.handleReset}
                 maxValues={maxValues}
                 handleChangeSwitch={this.handleChangeSwitch}
+                handleClose={this.handleCloseDialog}
+                handleEncrypt={this.handleEncryptSwitch}
             />
         )
     }

--- a/src/components/android-settings-container.js
+++ b/src/components/android-settings-container.js
@@ -47,18 +47,22 @@ class AndroidSettingsContainer extends React.Component {
         e.preventDefault()
 
         let { value } = e.target
-        
+
         if (e.target.name === 'reservedValues') {
             value = Math.min(maxValues.reservedValues, parseInt(value))
-        }
-      
-        if (e.target.name === 'encryptDB') {
-            value = e.target.checked
         }
 
         this.setState({
             ...this.state,
             [e.target.name]: value,
+        })
+        this.updateGlobal = true
+    }
+
+    handleChangeSwitch = e => {
+        this.setState({
+            ...this.state,
+            [e.target.name]: e.target.checked,
         })
         this.updateGlobal = true
     }
@@ -172,9 +176,9 @@ class AndroidSettingsContainer extends React.Component {
                                       dataSync: dataSync,
                                       numberSmsToSend: '',
                                       numberSmsConfirmation: '',
-                                      reservedValues: reservedValues,,
+                                      reservedValues: reservedValues,
                                       encryptDB: encryptDB,
-                                  })          
+                                  })
                                   .then(res => {
                                       this.setState({
                                           metadataSync: metadataSync,
@@ -236,6 +240,7 @@ class AndroidSettingsContainer extends React.Component {
                 checkMatchingConfirmation={this.checkMatchingConfirmation}
                 handleReset={this.handleReset}
                 maxValues={maxValues}
+                handleChangeSwitch={this.handleChangeSwitch}
             />
         )
     }

--- a/src/components/android-settings.js
+++ b/src/components/android-settings.js
@@ -7,6 +7,7 @@ import FormControlLabel from '@material-ui/core/FormControlLabel'
 import { Button } from '@dhis2/ui-core'
 import i18n from '@dhis2/d2-i18n'
 import PropTypes from '@dhis2/prop-types'
+import DialogEncrypt from './dialog-encrypt'
 
 import buttonStyles from '../styles/Button.module.css'
 
@@ -19,117 +20,132 @@ const AndroidSettings = ({
     handleReset,
     maxValues,
     handleChangeSwitch,
+    handleClose,
+    handleEncrypt,
 }) => {
     return (
-        <form>
-            <TextField
-                id="metadataSync"
-                name="metadataSync"
-                label={i18n.t('Metadata Sync')}
-                margin="normal"
-                select
-                fullWidth
-                InputLabelProps={{
-                    shrink: true,
-                }}
-                value={state.metadataSync}
-                onChange={handleChange}
-            >
-                {metadataOptions.map(option => (
-                    <MenuItem key={option.value} value={option.value}>
-                        {option.label}
-                    </MenuItem>
-                ))}
-            </TextField>
+        <>
+            <form>
+                <TextField
+                    id="metadataSync"
+                    name="metadataSync"
+                    label={i18n.t('Metadata Sync')}
+                    margin="normal"
+                    select
+                    fullWidth
+                    InputLabelProps={{
+                        shrink: true,
+                    }}
+                    value={state.metadataSync}
+                    onChange={handleChange}
+                >
+                    {metadataOptions.map(option => (
+                        <MenuItem key={option.value} value={option.value}>
+                            {option.label}
+                        </MenuItem>
+                    ))}
+                </TextField>
 
-            <TextField
-                id="dataSync"
-                name="dataSync"
-                label={i18n.t('Data Sync')}
-                margin="normal"
-                select
-                fullWidth
-                InputLabelProps={{
-                    shrink: true,
-                }}
-                value={state.dataSync}
-                onChange={handleChange}
-            >
-                {dataOptions.map(option => (
-                    <MenuItem key={option.value} value={option.value}>
-                        {option.label}
-                    </MenuItem>
-                ))}
-            </TextField>
+                <TextField
+                    id="dataSync"
+                    name="dataSync"
+                    label={i18n.t('Data Sync')}
+                    margin="normal"
+                    select
+                    fullWidth
+                    InputLabelProps={{
+                        shrink: true,
+                    }}
+                    value={state.dataSync}
+                    onChange={handleChange}
+                >
+                    {dataOptions.map(option => (
+                        <MenuItem key={option.value} value={option.value}>
+                            {option.label}
+                        </MenuItem>
+                    ))}
+                </TextField>
 
-            <TextField
-                id="numberSmsToSend"
-                name="numberSmsToSend"
-                label={i18n.t('SMS Gateway Phone number where SMS are sent')}
-                margin="normal"
-                fullWidth
-                InputLabelProps={{
-                    shrink: true,
-                }}
-                value={state.numberSmsToSend}
-                onChange={handleChange}
-                onBlur={checkMatchingConfirmation}
+                <TextField
+                    id="numberSmsToSend"
+                    name="numberSmsToSend"
+                    label={i18n.t(
+                        'SMS Gateway Phone number where SMS are sent'
+                    )}
+                    margin="normal"
+                    fullWidth
+                    InputLabelProps={{
+                        shrink: true,
+                    }}
+                    value={state.numberSmsToSend}
+                    onChange={handleChange}
+                    onBlur={checkMatchingConfirmation}
+                />
+
+                <TextField
+                    id="numberSmsConfirmation"
+                    name="numberSmsConfirmation"
+                    label={i18n.t('Confirm SMS Gateway Phone number')}
+                    margin="normal"
+                    fullWidth
+                    InputLabelProps={{
+                        shrink: true,
+                    }}
+                    value={state.numberSmsConfirmation}
+                    onChange={handleChange}
+                    onBlur={checkMatchingConfirmation}
+                    error={state.errorConfirmation}
+                />
+
+                <TextField
+                    id="reservedValues"
+                    label={i18n.t(
+                        'Reserved values downloaded per TEI attribute'
+                    )}
+                    name="reservedValues"
+                    type="number"
+                    margin="normal"
+                    fullWidth
+                    InputLabelProps={{
+                        shrink: true,
+                    }}
+                    InputProps={{
+                        inputProps: {
+                            min: 0,
+                            step: 10,
+                            max: maxValues.reservedValues,
+                        },
+                    }}
+                    value={state.reservedValues}
+                    onChange={handleChange}
+                />
+
+                <FormControlLabel
+                    control={
+                        <Switch
+                            checked={state.encryptDB}
+                            onChange={handleChangeSwitch}
+                            name="encryptDB"
+                            color="primary"
+                        />
+                    }
+                    label={i18n.t('Encrypt DB')}
+                />
+
+                <div className={buttonStyles.mainContent__button__container}>
+                    <Button onClick={handleReset} primary>
+                        {i18n.t('SET TO DEFAULT')}
+                    </Button>
+                </div>
+            </form>
+
+            <DialogEncrypt
+                openDialog={state.openDialog}
+                checked={state.encryptDB}
+                onClose={handleClose}
+                handleEncrypt={handleEncrypt}
             />
-
-            <TextField
-                id="numberSmsConfirmation"
-                name="numberSmsConfirmation"
-                label={i18n.t('Confirm SMS Gateway Phone number')}
-                margin="normal"
-                fullWidth
-                InputLabelProps={{
-                    shrink: true,
-                }}
-                value={state.numberSmsConfirmation}
-                onChange={handleChange}
-                onBlur={checkMatchingConfirmation}
-                error={state.errorConfirmation}
-            />
-
-            <TextField
-                id="reservedValues"
-                label={i18n.t('Reserved values downloaded per TEI attribute')}
-                name="reservedValues"
-                type="number"
-                margin="normal"
-                fullWidth
-                InputLabelProps={{
-                    shrink: true,
-                }}
-                InputProps={{
-                    inputProps: {
-                        min: 0,
-                        step: 10,
-                        max: maxValues.reservedValues,
-                    },
-                }}
-                value={state.reservedValues}
-                onChange={handleChange}
-            />
-
-            <FormControlLabel
-                control={
-                    <Switch
-                        checked={state.encryptDB}
-                        onChange={handleChangeSwitch}
-                        name="encryptDB"
-                        color="primary"
-                    />
-                }
-                label={i18n.t('Encrypt DB')}
-            />
-
-            <div className={buttonStyles.mainContent__button__container}>
-                <Button onClick={handleReset} primary>
-                    {i18n.t('SET TO DEFAULT')}
-                </Button>
-            </div>
-        </form>
+        </>
     )
 }
 

--- a/src/components/android-settings.js
+++ b/src/components/android-settings.js
@@ -158,6 +158,8 @@ AndroidSettings.propTypes = {
     handleReset: PropTypes.func.isRequired,
     maxValues: PropTypes.object.isRequired,
     handleChangeSwitch: PropTypes.func.isRequired,
+    handleClose: PropTypes.func.isRequired,
+    handleEncrypt: PropTypes.func.isRequired,
 }
 
 export default AndroidSettings

--- a/src/components/android-settings.js
+++ b/src/components/android-settings.js
@@ -18,6 +18,7 @@ const AndroidSettings = ({
     checkMatchingConfirmation,
     handleReset,
     maxValues,
+    handleChangeSwitch,
 }) => {
     return (
         <form>
@@ -115,7 +116,7 @@ const AndroidSettings = ({
                 control={
                     <Switch
                         checked={state.encryptDB}
-                        onChange={handleChange}
+                        onChange={handleChangeSwitch}
                         name="encryptDB"
                         color="primary"
                     />
@@ -140,6 +141,7 @@ AndroidSettings.propTypes = {
     checkMatchingConfirmation: PropTypes.func.isRequired,
     handleReset: PropTypes.func.isRequired,
     maxValues: PropTypes.object.isRequired,
+    handleChangeSwitch: PropTypes.func.isRequired,
 }
 
 export default AndroidSettings

--- a/src/components/dialog-encrypt.js
+++ b/src/components/dialog-encrypt.js
@@ -1,0 +1,75 @@
+import React from 'react'
+import {
+    Modal,
+    ModalTitle,
+    ModalContent,
+    ModalActions,
+    ButtonStrip,
+    Button,
+} from '@dhis2/ui-core'
+import { encryptTitles } from '../constants/android-settings'
+import i18n from '@dhis2/d2-i18n'
+import PropTypes from '@dhis2/prop-types'
+
+const DialogEncrypt = ({ openDialog, onClose, checked, handleEncrypt }) => {
+    let encrypt
+
+    if (checked) {
+        encrypt = encryptTitles.decrypt
+    } else {
+        encrypt = encryptTitles.encrypt
+    }
+
+    return (
+        <>
+            {openDialog && (
+                <Modal small onClose={onClose} position="middle">
+                    <ModalTitle dataTest="dhis2-uicore-modaltitle">
+                        {i18n.t('{{encrypt}} DB', { encrypt })}
+                    </ModalTitle>
+                    <ModalContent>
+                        {i18n.t(
+                            '{{encrypt}} data base is a critical action that could have very serious consequences. Are you sure you want to {{encrypt}} DB?',
+                            { encrypt }
+                        )}
+                    </ModalContent>
+                    <ModalActions>
+                        <ButtonStrip end>
+                            <Button onClick={onClose}>
+                                {i18n.t('Cancel')}
+                            </Button>
+                            {checked ? (
+                                <Button
+                                    onClick={() => {
+                                        handleEncrypt(checked)
+                                    }}
+                                    primary
+                                >
+                                    {i18n.t('Decrypt DB')}
+                                </Button>
+                            ) : (
+                                <Button
+                                    onClick={() => {
+                                        handleEncrypt(checked)
+                                    }}
+                                    destructive
+                                >
+                                    {i18n.t('Encrypt DB')}
+                                </Button>
+                            )}
+                        </ButtonStrip>
+                    </ModalActions>
+                </Modal>
+            )}
+        </>
+    )
+}
+
+DialogEncrypt.propTypes = {
+    openDialog: PropTypes.bool.isRequired,
+    checked: PropTypes.bool.isRequired,
+    onClose: PropTypes.func.isRequired,
+    handleEncrypt: PropTypes.func.isRequired,
+}
+
+export default DialogEncrypt

--- a/src/constants/android-settings.js
+++ b/src/constants/android-settings.js
@@ -1,3 +1,5 @@
+import i18n from '@dhis2/d2-i18n'
+
 export const metadataOptions = [
     {
         value: '1h',
@@ -42,6 +44,11 @@ export const dataOptions = [
 
 export const maxValues = {
     reservedValues: 50,
+}
+
+export const encryptTitles = {
+    encrypt: i18n.t('Encrypt'),
+    decrypt: i18n.t('Decrypt'),
 }
 
 export const androidSettingsDefault = {


### PR DESCRIPTION
This PR has:

Fixing the double click for `encryptDB` switch. At the beginning sometimes it needed to double click switch to change the state from checked to not checked.