### PR TITLE
fix: specific setting program and data set choice disappears

### DIFF
--- a/src/components/sections/dataset/dataSet-settings.js
+++ b/src/components/sections/dataset/dataSet-settings.js
@@ -196,15 +196,19 @@ class DataSetSettings extends React.Component {
                 specificSettings,
                 rowSettings,
                 nameList,
+                optionList,
             } = removeSettingFromList({
                 row: this.argsRow,
                 specificSettings: this.specificSettings,
                 rowSettings: this.specificSettingsRows,
                 nameList: this.dataSetNamesList,
+                optionList: this.dataSetList,
+                listComplete: this.dataSetListComplete,
             })
             this.specificSettings = specificSettings
             this.specificSettingsRows = rowSettings
             this.dataSetNamesList = nameList
+            this.dataSetList = optionList
             this.setState({
                 deleteDialog: {
                     open: false,

--- a/src/components/sections/program/program-settings.js
+++ b/src/components/sections/program/program-settings.js
@@ -251,15 +251,19 @@ class ProgramSettings extends React.Component {
                 specificSettings,
                 rowSettings,
                 nameList,
+                optionList,
             } = removeSettingFromList({
                 row: this.argsRow,
                 specificSettings: this.specificSettings,
                 rowSettings: this.specificSettingsRows,
                 nameList: this.programNamesList,
+                optionList: this.programList,
+                listComplete: this.programListComplete,
             })
             this.specificSettings = specificSettings
             this.specificSettingsRows = rowSettings
             this.programNamesList = nameList
+            this.programList = optionList
             this.setState({
                 deleteDialog: {
                     open: false,

--- a/src/modules/getItemFromList.js
+++ b/src/modules/getItemFromList.js
@@ -12,6 +12,8 @@ export const getItemFromList = (usedList, completeList, updatedList) => {
         updatedList = settingCompleteList.filter(
             item => !usedIdList.includes(item.id)
         )
+    } else {
+        updatedList = completeList
     }
 
     return updatedList

--- a/src/modules/removeSettingFromList.js
+++ b/src/modules/removeSettingFromList.js
@@ -1,11 +1,15 @@
 /**
  * When delete specific settings, should remove it from specific settings list
  * */
+import { getItemFromList } from './getItemFromList'
+
 export const removeSettingFromList = ({
     row,
     specificSettings,
     rowSettings,
     nameList,
+    optionList,
+    listComplete,
 }) => {
     const data = row
     const oldList = specificSettings
@@ -25,9 +29,12 @@ export const removeSettingFromList = ({
     rowSettings = rowList.filter(row => row.id !== data.id)
     specificSettings = newList
 
+    optionList = getItemFromList(nameList, listComplete, optionList)
+
     return {
         specificSettings,
         rowSettings,
         nameList,
+        optionList,
     }
 }


### PR DESCRIPTION
This PR fixes a [Jira issue](https://jira.dhis2.org/browse/DHIS2-8793), the specific program/data set choice disappears when:

Steps:

1. Program/ Data set settings
2. Click Add program/data set a specific setting
3. Choose Antenatal Care Visit/Art summary monthly  and click Add/Save
4. Click Edit
5. Change the value and click Add/Save
6. Click Delete and confirm
7. Open Add program/data set specific setting. Notice that item is now missing from the menu