### PR TITLE
Fix/history routes

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-05-21T20:09:14.574Z\n"
-"PO-Revision-Date: 2020-05-21T20:09:14.574Z\n"
+"POT-Creation-Date: 2020-06-18T06:56:04.402Z\n"
+"PO-Revision-Date: 2020-06-18T06:56:04.402Z\n"
 
 msgid "Failed to get data from Data Store"
 msgstr ""
@@ -27,6 +27,17 @@ msgid "Cancel"
 msgstr ""
 
 msgid "Delete"
+msgstr ""
+
+msgid "Disable all settings"
+msgstr ""
+
+msgid ""
+"This action will disable and remove all General, Program and Data set "
+"settings. Are you sure you want to disable all settings?"
+msgstr ""
+
+msgid "Disable"
 msgstr ""
 
 msgid "{{encrypt}} the device database"
@@ -92,6 +103,15 @@ msgstr ""
 msgid "Add/Save"
 msgstr ""
 
+msgid "404 Page not found."
+msgstr ""
+
+msgid "No match for"
+msgstr ""
+
+msgid "Go back to General settings"
+msgstr ""
+
 msgid "Name"
 msgstr ""
 
@@ -107,10 +127,12 @@ msgstr ""
 msgid "SMS Gateway phone number"
 msgstr ""
 
-msgid "Incorrect phone number"
+msgid ""
+"This phone number is not valid. Must start with + and be at least 4 "
+"characters long."
 msgstr ""
 
-msgid "Phone number that receives all SMS messages"
+msgid "Must start with + and be at least 4 characters long."
 msgstr ""
 
 msgid "SMS Result Sender phone number"
@@ -128,10 +150,10 @@ msgid ""
 "on an external server."
 msgstr ""
 
-msgid "Reset all values to default"
+msgid "This will disable and remove all General, Program and Data set settings."
 msgstr ""
 
-msgid "Disable settings"
+msgid "Reset all values to default"
 msgstr ""
 
 msgid "General download sync settings"

--- a/src/components/dialog/dialog-disable-settings.js
+++ b/src/components/dialog/dialog-disable-settings.js
@@ -1,0 +1,47 @@
+import React from 'react'
+
+import {
+    Modal,
+    ModalTitle,
+    ModalContent,
+    ModalActions,
+    ButtonStrip,
+    Button,
+} from '@dhis2/ui-core'
+import i18n from '@dhis2/d2-i18n'
+import PropTypes from '@dhis2/prop-types'
+
+const DialogDisableSettings = ({ openDialog, onClose, disableSettings }) => {
+    return (
+        <>
+            {openDialog && (
+                <Modal small position="middle" onClose={onClose}>
+                    <ModalTitle>{i18n.t('Disable all settings')}</ModalTitle>
+                    <ModalContent>
+                        {i18n.t(
+                            'This action will disable and remove all General, Program and Data set settings. Are you sure you want to disable all settings?'
+                        )}
+                    </ModalContent>
+                    <ModalActions>
+                        <ButtonStrip end>
+                            <Button onClick={onClose}>
+                                {i18n.t('Cancel')}
+                            </Button>
+                            <Button onClick={disableSettings} primary>
+                                {i18n.t('Disable')}
+                            </Button>
+                        </ButtonStrip>
+                    </ModalActions>
+                </Modal>
+            )}
+        </>
+    )
+}
+
+DialogDisableSettings.propTypes = {
+    openDialog: PropTypes.bool.isRequired,
+    onClose: PropTypes.func.isRequired,
+    disableSettings: PropTypes.func.isRequired,
+}
+
+export default DialogDisableSettings

--- a/src/components/page-not-found.js
+++ b/src/components/page-not-found.js
@@ -1,0 +1,27 @@
+import React from 'react'
+
+import i18n from '@dhis2/d2-i18n'
+import { Link } from 'react-router-dom'
+import styles from '../styles/LayoutTitles.module.css'
+
+const PageNotFound = () => {
+    let path = location.hash
+    path = path.split('#')[1]
+
+    return (
+        <div>
+            <p className={styles.mainContent__title_headerBar}>
+                {i18n.t('404 Page not found.')}
+            </p>
+            <p
+                className={`${styles.mainContent__subtitle} ${styles.margin_top40}`}
+            >
+                {i18n.t('No match for')}
+                <code> {path} </code>
+            </p>
+            <Link to="/"> {i18n.t('Go back to General settings')}</Link>
+        </div>
+    )
+}
+
+export default PageNotFound

--- a/src/components/sections/general/android-settings-container.js
+++ b/src/components/sections/general/android-settings-container.js
@@ -14,35 +14,17 @@ const AndroidSettingsContainer = () => {
         success: false,
         error: false,
     })
-    const [openDialog, setOpenDialog] = useState({
-        encryptDB: false,
-        saveData: false,
-        disableSettings: false,
-    })
+
     const [loading, setLoading] = useState(true)
     const [openErrorAlert, setOpenErrorAlert] = useState(false)
     const { reloadPage, navigateTo } = useNavigation()
+    const form = useGeneralForm({ setSubmitDataStore })
     const {
-        handleChange,
-        handleReset,
-        handleCheckbox,
-        validatePhoneNumber,
-        generalParameters,
-        setGeneralParameters,
-        errorNumber,
-        disableSave,
-        setDisableSave,
-    } = useGeneralForm({
+        handleSaveDataDialog,
         setOpenDialog,
-        setOpenErrorAlert,
         openDialog,
-        setSubmitDataStore,
-    })
-    const handleSaveDataDialog = useSaveGeneralSettings({
-        generalParameters,
-        openDialog,
-        setOpenDialog,
-        setDisableSave,
+    } = useSaveGeneralSettings({
+        form,
         setSubmitDataStore,
     })
 
@@ -53,9 +35,8 @@ const AndroidSettingsContainer = () => {
         apiLoadGeneralSettings()
             .then(generalSettings => {
                 if (generalSettings) {
-                    setGeneralParameters(generalSettings)
+                    form.setInitialData(generalSettings)
                     setLoading(false)
-                    setDisableSave(true)
                 } else {
                     navigateTo('/')
                 }
@@ -105,22 +86,15 @@ const AndroidSettingsContainer = () => {
 
     return (
         <>
-            <UnsavedChangesAlert unsavedChanges={!disableSave} />
+            <UnsavedChangesAlert unsavedChanges={!form.disableSave} />
 
             <GeneralSettings
                 state={{
-                    generalParameters,
-                    loading,
-                    errorNumber,
                     openDialog,
-                    disableSave,
                     submitDataStore,
                     openErrorAlert,
                 }}
-                handleChange={handleChange}
-                validatePhoneNumber={validatePhoneNumber}
-                handleReset={handleReset}
-                handleEncryptCheckbox={handleCheckbox}
+                generalForm={form}
                 handleSaveDialog={handleSaveDataDialog}
                 handleDisableSettings={handleDisableSettings}
             />

--- a/src/components/sections/general/android-settings-container.js
+++ b/src/components/sections/general/android-settings-container.js
@@ -1,291 +1,131 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 
 import { CircularLoader } from '@dhis2/ui-core'
-import api from '../../../utils/api'
-
-import {
-    androidSettingsDefault,
-    maxValues,
-    RESERVED_VALUES,
-} from '../../../constants/android-settings'
 import GeneralSettings from './general-settings'
-import { NAMESPACE, GENERAL_SETTINGS } from '../../../constants/data-store'
 import UnsavedChangesAlert from '../../unsaved-changes-alert'
 import { apiLoadGeneralSettings } from '../../../modules/general/apiLoadSettings'
-import { validateNumber } from '../../../modules/general/validatePhoneNumber'
 import { removeNamespace } from '../../../modules/general/removeNamespace'
+import { useNavigation } from '../../../utils/useNavigation'
+import { useGeneralForm } from '../../../modules/general/useGeneralForm'
+import { useSaveGeneralSettings } from '../../../modules/general/useSaveGeneralSettings'
 
-const {
-    metadataSync,
-    dataSync,
-    encryptDB,
-    reservedValues,
-} = androidSettingsDefault
-
-class AndroidSettingsContainer extends React.Component {
-    constructor(props) {
-        super(props)
-    }
-
-    state = {
-        metadataSync,
-        dataSync,
-        numberSmsToSend: '',
-        numberSmsConfirmation: '',
-        reservedValues,
-        encryptDB,
-        loading: true,
-        errorConfirmation: false,
-        openDialog: false,
-        openDialogSaveData: false,
-        disableSave: true,
-        submitDataStore: {
-            success: false,
-            error: false,
-        },
-        openErrorAlert: false,
-        errorGateway: false,
-    }
-
-    /**
-     * Updates global settings on fly
-     */
-    handleChange = e => {
-        e.preventDefault()
-
-        let { value } = e.target
-
-        if (e.target.name === RESERVED_VALUES) {
-            value = Math.min(maxValues.reservedValues, parseInt(value))
-        }
-
-        this.setState({
-            ...this.state,
-            disableSave:
-                this.state.errorGateway || this.state.errorConfirmation,
-            submitDataStore: {
-                success: false,
-                error: false,
-            },
-            [e.target.name]: value,
-        })
-    }
-
-    /**
-     * When using checkbox for Encrypt DB should open dialog
-     * onChange: When Checkbox is checked or not opens dialog
-     * onClose: close Encrypt DB dialog
-     * handleEncrypt: Changes value for encryptDB state
-     */
-
-    handleCheckbox = {
-        onChange: () => {
-            this.setState({
-                ...this.state,
-                openDialog: true,
-                submitDataStore: {
-                    success: false,
-                    error: false,
-                },
-            })
-        },
-        onClose: () => {
-            this.setState({
-                ...this.state,
-                openDialog: false,
-            })
-        },
-        handleEncrypt: isChecked => {
-            this.setState({
-                ...this.state,
-                encryptDB: !isChecked,
-                openDialog: false,
-                disableSave: false,
-            })
-        },
-    }
-
-    /**
-     * Checks if sms number or confirmation number is valid
-     */
-    validatePhoneNumber = {
-        gatewayNumber: () => {
-            if (![null, '', false].includes(this.state.numberSmsToSend)) {
-                const validInput = validateNumber(this.state.numberSmsToSend)
-                !validInput
-                    ? this.setState({ errorGateway: true, disableSave: true })
-                    : this.setState({ errorGateway: false })
-            } else {
-                this.setState({ errorGateway: false })
-            }
-        },
-        confirmationNumber: () => {
-            if (![null, '', false].includes(this.state.numberSmsConfirmation)) {
-                const validInput = validateNumber(
-                    this.state.numberSmsConfirmation
-                )
-                !validInput
-                    ? this.setState({
-                          errorConfirmation: true,
-                          disableSave: true,
-                      })
-                    : this.setState({ errorConfirmation: false })
-            } else {
-                this.setState({ errorConfirmation: false })
-            }
-        },
-    }
-
-    /**
-     * Updates Settings calling update api,
-     * check if gateway and confirmation number are not empty
-     * Prevent null console warning
-     */
-    submitData = () => {
-        const androidData = {
-            metadataSync: this.state.metadataSync,
-            dataSync: this.state.dataSync,
-            reservedValues: this.state.reservedValues,
-            encryptDB: this.state.encryptDB,
-            lastUpdated: new Date().toJSON(),
-        }
-
-        if (!['', null, undefined].includes(this.state.numberSmsToSend)) {
-            androidData.numberSmsToSend = this.state.numberSmsToSend
-        }
-
-        if (!['', null, undefined].includes(this.state.numberSmsConfirmation)) {
-            androidData.numberSmsConfirmation = this.state.numberSmsConfirmation
-        }
-
-        this.saveDataApi(androidData)
-    }
-
-    /**
-     * Handle update api method to save settings in dataStore also shows alertBar for success and error
-     * */
-    saveDataApi = data => {
-        api.updateValue(NAMESPACE, GENERAL_SETTINGS, data)
-            .then(() => {
-                this.setState({
-                    submitDataStore: {
-                        success: true,
-                        error: false,
-                    },
-                })
-            })
-            .catch(e => {
-                console.error(e)
-                this.setState({
-                    submitDataStore: {
-                        success: false,
-                        error: true,
-                    },
-                })
-            })
-    }
-
-    /**
-     * Sets values to default
-     */
-    handleReset = () => {
-        this.setState({
-            metadataSync,
-            dataSync,
-            numberSmsToSend: '',
-            numberSmsConfirmation: '',
-            reservedValues,
-            encryptDB,
-            openDialog: false,
-            disableSave: false,
-            submitDataStore: {
-                success: false,
-                error: false,
-            },
-            openErrorAlert: false,
-        })
-    }
-
-    /**
-     * Handle save DataStore dialog
-     * */
-    handleSaveDataDialog = {
-        open: () => {
-            this.setState({
-                openDialogSaveData: true,
-            })
-        },
-        close: () => {
-            this.setState({
-                openDialogSaveData: false,
-            })
-        },
-        save: () => {
-            this.submitData()
-            this.setState({
-                openDialogSaveData: false,
-                disableSave: true,
-            })
-        },
-    }
-
-    /**
-     * Remove namespaces and keynames
-     * */
-
-    removeNamespace = () => {
-        removeNamespace()
-            .then(() => {
-                console.info('remove namespace')
-                location.replace('/')
-            })
-            .catch(e => {
-                console.error(e)
-            })
-    }
+const AndroidSettingsContainer = () => {
+    const [submitDataStore, setSubmitDataStore] = useState({
+        success: false,
+        error: false,
+    })
+    const [openDialog, setOpenDialog] = useState({
+        encryptDB: false,
+        saveData: false,
+        disableSettings: false,
+    })
+    const [loading, setLoading] = useState(true)
+    const [openErrorAlert, setOpenErrorAlert] = useState(false)
+    const { reloadPage, navigateTo } = useNavigation()
+    const {
+        handleChange,
+        handleReset,
+        handleCheckbox,
+        validatePhoneNumber,
+        generalParameters,
+        setGeneralParameters,
+        errorNumber,
+        disableSave,
+        setDisableSave,
+    } = useGeneralForm({
+        setOpenDialog,
+        setOpenErrorAlert,
+        openDialog,
+        setSubmitDataStore,
+    })
+    const handleSaveDataDialog = useSaveGeneralSettings({
+        generalParameters,
+        openDialog,
+        setOpenDialog,
+        setDisableSave,
+        setSubmitDataStore,
+    })
 
     /**
      * When component mount, get namespace and keys from dataStore
      */
-    componentDidMount() {
+    useEffect(() => {
         apiLoadGeneralSettings()
             .then(generalSettings => {
-                this.setState({
-                    ...generalSettings,
-                    loading: false,
-                    disableSave: true,
-                })
+                if (generalSettings) {
+                    setGeneralParameters(generalSettings)
+                    setLoading(false)
+                    setDisableSave(true)
+                } else {
+                    navigateTo('/')
+                }
             })
             .catch(e => {
                 console.error(e)
-                this.setState({
-                    loading: false,
-                    openErrorAlert: true,
-                })
+                setLoading(false)
+                setOpenErrorAlert(true)
             })
+    }, [])
+
+    /**
+     * Methods to handle Dialog that disable/remove settings
+     * open: flag to open dialog
+     * cancel: flag to close dialog
+     * disableSettings: method to remove namespace and keyNames
+     * */
+
+    const handleDisableSettings = {
+        open: () => {
+            setOpenDialog({
+                ...openDialog,
+                disableSettings: true,
+            })
+        },
+        cancel: () => {
+            setOpenDialog({
+                ...openDialog,
+                disableSettings: false,
+            })
+        },
+        disableSettings: () => {
+            removeNamespace()
+                .then(() => {
+                    console.info('remove namespace')
+                    reloadPage()
+                })
+                .catch(e => {
+                    console.error(e)
+                })
+        },
     }
 
-    render() {
-        if (this.state.loading === true) {
-            return <CircularLoader small />
-        }
-
-        return (
-            <>
-                <UnsavedChangesAlert unsavedChanges={!this.state.disableSave} />
-
-                <GeneralSettings
-                    state={this.state}
-                    handleChange={this.handleChange}
-                    validatePhoneNumber={this.validatePhoneNumber}
-                    handleReset={this.handleReset}
-                    handleEncryptCheckbox={this.handleCheckbox}
-                    handleSaveDialog={this.handleSaveDataDialog}
-                    removeNamespace={this.removeNamespace}
-                />
-            </>
-        )
+    if (loading === true) {
+        return <CircularLoader small />
     }
+
+    return (
+        <>
+            <UnsavedChangesAlert unsavedChanges={!disableSave} />
+
+            <GeneralSettings
+                state={{
+                    generalParameters,
+                    loading,
+                    errorNumber,
+                    openDialog,
+                    disableSave,
+                    submitDataStore,
+                    openErrorAlert,
+                }}
+                handleChange={handleChange}
+                validatePhoneNumber={validatePhoneNumber}
+                handleReset={handleReset}
+                handleEncryptCheckbox={handleCheckbox}
+                handleSaveDialog={handleSaveDataDialog}
+                handleDisableSettings={handleDisableSettings}
+            />
+        </>
+    )
 }
 
 export default AndroidSettingsContainer

--- a/src/components/sections/general/general-form.js
+++ b/src/components/sections/general/general-form.js
@@ -6,7 +6,7 @@ import {
     maxValues,
     metadataOptions,
 } from '../../../constants/android-settings'
-import { Button, ButtonStrip, CheckboxField } from '@dhis2/ui-core'
+import { Button, ButtonStrip, CheckboxField, Help } from '@dhis2/ui-core'
 import MenuItem from '@material-ui/core/MenuItem'
 import i18n from '@dhis2/d2-i18n'
 import PropTypes from '@dhis2/prop-types'
@@ -21,7 +21,7 @@ const GeneralForm = ({
     handleEncryptCheckbox,
     handleSaveDialog,
     handleReset,
-    removeNamespace,
+    handleDisableSettings,
 }) => {
     return (
         <form>
@@ -35,7 +35,7 @@ const GeneralForm = ({
                 InputLabelProps={{
                     shrink: true,
                 }}
-                value={state.metadataSync}
+                value={state.generalParameters.metadataSync}
                 onChange={handleChange}
             >
                 {metadataOptions.map(option => (
@@ -55,7 +55,7 @@ const GeneralForm = ({
                 InputLabelProps={{
                     shrink: true,
                 }}
-                value={state.dataSync}
+                value={state.generalParameters.dataSync}
                 onChange={handleChange}
             >
                 {dataOptions.map(option => (
@@ -77,7 +77,7 @@ const GeneralForm = ({
                 }}
                 label={i18n.t('SMS Gateway phone number')}
                 helperText={
-                    state.errorGateway
+                    state.errorNumber.gateway
                         ? i18n.t(
                               'This phone number is not valid. Must start with + and be at least 4 characters long.'
                           )
@@ -90,10 +90,10 @@ const GeneralForm = ({
                 InputLabelProps={{
                     shrink: true,
                 }}
-                value={state.numberSmsToSend}
+                value={state.generalParameters.numberSmsToSend}
                 onChange={handleChange}
                 onKeyUp={validatePhoneNumber.gatewayNumber}
-                error={state.errorGateway}
+                error={state.errorNumber.gateway}
             />
 
             <TextField
@@ -108,7 +108,7 @@ const GeneralForm = ({
                 }}
                 label={i18n.t('SMS Result Sender phone number')}
                 helperText={
-                    state.errorConfirmation
+                    state.errorNumber.confirmation
                         ? i18n.t(
                               'This phone number is not valid. Must start with + and be at least 4 characters long.'
                           )
@@ -121,10 +121,10 @@ const GeneralForm = ({
                 InputLabelProps={{
                     shrink: true,
                 }}
-                value={state.numberSmsConfirmation}
+                value={state.generalParameters.numberSmsConfirmation}
                 onChange={handleChange}
                 onKeyUp={validatePhoneNumber.confirmationNumber}
-                error={state.errorConfirmation}
+                error={state.errorNumber.confirmation}
             />
 
             <TextField
@@ -144,20 +144,31 @@ const GeneralForm = ({
                         max: maxValues.reservedValues,
                     },
                 }}
-                value={state.reservedValues}
+                value={state.generalParameters.reservedValues}
                 onChange={handleChange}
             />
 
             <div className={styles.field__form__container}>
                 <CheckboxField
                     name="encryptDB"
-                    checked={state.encryptDB}
+                    checked={state.generalParameters.encryptDB}
                     onChange={handleEncryptCheckbox.onChange}
                     label={i18n.t('Encrypt device database')}
                     helpText={i18n.t(
                         'Encrypt all data stored on device. Data can be lost if there are problems with an encrypted database. This will not affect the DHIS2 database stored on an external server.'
                     )}
                 />
+            </div>
+
+            <div>
+                <Button onClick={handleDisableSettings.open}>
+                    {i18n.t('Disable all settings')}
+                </Button>
+                <Help>
+                    {i18n.t(
+                        'This will disable and remove all General, Program and Data set settings.'
+                    )}
+                </Help>
             </div>
 
             <ButtonStrip className={buttonStyles.container__padding}>
@@ -172,9 +183,6 @@ const GeneralForm = ({
                 <Button onClick={handleReset}>
                     {i18n.t('Reset all values to default')}
                 </Button>
-                <Button onClick={removeNamespace}>
-                    {i18n.t('Disable settings')}
-                </Button>
             </ButtonStrip>
         </form>
     )
@@ -187,6 +195,7 @@ GeneralForm.propTypes = {
     handleReset: PropTypes.func.isRequired,
     handleEncryptCheckbox: PropTypes.object.isRequired,
     handleSaveDialog: PropTypes.object.isRequired,
+    handleDisableSettings: PropTypes.object.isRequired,
 }
 
 export default GeneralForm

--- a/src/components/sections/general/general-form.js
+++ b/src/components/sections/general/general-form.js
@@ -15,19 +15,13 @@ import styles from '../../../styles/LayoutTitles.module.css'
 import buttonStyles from '../../../styles/Button.module.css'
 
 const GeneralForm = ({
-    state,
-    handleChange,
-    validatePhoneNumber,
-    handleEncryptCheckbox,
     handleSaveDialog,
-    handleReset,
+    handleForm,
     handleDisableSettings,
 }) => {
     return (
         <form>
             <TextField
-                id="metadataSync"
-                name="metadataSync"
                 label={i18n.t('How often should metadata sync?')}
                 margin="normal"
                 select
@@ -35,8 +29,7 @@ const GeneralForm = ({
                 InputLabelProps={{
                     shrink: true,
                 }}
-                value={state.generalParameters.metadataSync}
-                onChange={handleChange}
+                {...handleForm.getSelect('metadataSync')}
             >
                 {metadataOptions.map(option => (
                     <MenuItem key={option.value} value={option.value}>
@@ -46,8 +39,6 @@ const GeneralForm = ({
             </TextField>
 
             <TextField
-                id="dataSync"
-                name="dataSync"
                 label={i18n.t('How often should data sync?')}
                 margin="normal"
                 select
@@ -55,8 +46,7 @@ const GeneralForm = ({
                 InputLabelProps={{
                     shrink: true,
                 }}
-                value={state.generalParameters.dataSync}
-                onChange={handleChange}
+                {...handleForm.getSelect('dataSync')}
             >
                 {dataOptions.map(option => (
                     <MenuItem key={option.value} value={option.value}>
@@ -66,8 +56,6 @@ const GeneralForm = ({
             </TextField>
 
             <TextField
-                id="numberSmsToSend"
-                name="numberSmsToSend"
                 type="tel"
                 InputProps={{
                     inputProps: {
@@ -77,7 +65,7 @@ const GeneralForm = ({
                 }}
                 label={i18n.t('SMS Gateway phone number')}
                 helperText={
-                    state.errorNumber.gateway
+                    handleForm.errorNumber.numberSmsToSend
                         ? i18n.t(
                               'This phone number is not valid. Must start with + and be at least 4 characters long.'
                           )
@@ -90,15 +78,10 @@ const GeneralForm = ({
                 InputLabelProps={{
                     shrink: true,
                 }}
-                value={state.generalParameters.numberSmsToSend}
-                onChange={handleChange}
-                onKeyUp={validatePhoneNumber.gatewayNumber}
-                error={state.errorNumber.gateway}
+                {...handleForm.getPhoneNumber('numberSmsToSend')}
             />
 
             <TextField
-                id="numberSmsConfirmation"
-                name="numberSmsConfirmation"
                 type="tel"
                 InputProps={{
                     inputProps: {
@@ -108,7 +91,7 @@ const GeneralForm = ({
                 }}
                 label={i18n.t('SMS Result Sender phone number')}
                 helperText={
-                    state.errorNumber.confirmation
+                    handleForm.errorNumber.numberSmsConfirmation
                         ? i18n.t(
                               'This phone number is not valid. Must start with + and be at least 4 characters long.'
                           )
@@ -121,16 +104,11 @@ const GeneralForm = ({
                 InputLabelProps={{
                     shrink: true,
                 }}
-                value={state.generalParameters.numberSmsConfirmation}
-                onChange={handleChange}
-                onKeyUp={validatePhoneNumber.confirmationNumber}
-                error={state.errorNumber.confirmation}
+                {...handleForm.getPhoneNumber('numberSmsConfirmation')}
             />
 
             <TextField
-                id="reservedValues"
                 label={i18n.t('Reserved values downloaded per TEI attribute')}
-                name="reservedValues"
                 type="number"
                 margin="normal"
                 fullWidth
@@ -144,19 +122,16 @@ const GeneralForm = ({
                         max: maxValues.reservedValues,
                     },
                 }}
-                value={state.generalParameters.reservedValues}
-                onChange={handleChange}
+                {...handleForm.getInput('reservedValues')}
             />
 
             <div className={styles.field__form__container}>
                 <CheckboxField
-                    name="encryptDB"
-                    checked={state.generalParameters.encryptDB}
-                    onChange={handleEncryptCheckbox.onChange}
                     label={i18n.t('Encrypt device database')}
                     helpText={i18n.t(
                         'Encrypt all data stored on device. Data can be lost if there are problems with an encrypted database. This will not affect the DHIS2 database stored on an external server.'
                     )}
+                    {...handleForm.getCheckbox('encryptDB')}
                 />
             </div>
 
@@ -176,11 +151,11 @@ const GeneralForm = ({
                     primary
                     className={buttonStyles.button_marginLeft}
                     onClick={handleSaveDialog.open}
-                    disabled={state.disableSave}
+                    disabled={handleForm.disableSave}
                 >
                     {i18n.t('Save')}
                 </Button>
-                <Button onClick={handleReset}>
+                <Button onClick={handleForm.handleReset}>
                     {i18n.t('Reset all values to default')}
                 </Button>
             </ButtonStrip>
@@ -189,11 +164,7 @@ const GeneralForm = ({
 }
 
 GeneralForm.propTypes = {
-    state: PropTypes.object.isRequired,
-    handleChange: PropTypes.func.isRequired,
-    validatePhoneNumber: PropTypes.object.isRequired,
-    handleReset: PropTypes.func.isRequired,
-    handleEncryptCheckbox: PropTypes.object.isRequired,
+    handleForm: PropTypes.object.isRequired,
     handleSaveDialog: PropTypes.object.isRequired,
     handleDisableSettings: PropTypes.object.isRequired,
 }

--- a/src/components/sections/general/general-settings.js
+++ b/src/components/sections/general/general-settings.js
@@ -14,10 +14,7 @@ import DialogDisableSettings from '../../dialog/dialog-disable-settings'
 
 const GeneralSettings = ({
     state,
-    handleChange,
-    validatePhoneNumber,
-    handleReset,
-    handleEncryptCheckbox,
+    generalForm,
     handleSaveDialog,
     handleDisableSettings,
 }) => {
@@ -33,20 +30,16 @@ const GeneralSettings = ({
             </div>
 
             <GeneralForm
-                state={state}
-                handleChange={handleChange}
-                validatePhoneNumber={validatePhoneNumber}
-                handleReset={handleReset}
-                handleEncryptCheckbox={handleEncryptCheckbox}
+                handleForm={generalForm}
                 handleSaveDialog={handleSaveDialog}
                 handleDisableSettings={handleDisableSettings}
             />
 
             <DialogEncrypt
-                openDialog={state.openDialog.encryptDB}
-                checked={state.generalParameters.encryptDB}
-                onClose={handleEncryptCheckbox.onClose}
-                handleEncrypt={handleEncryptCheckbox.handleEncrypt}
+                openDialog={generalForm.openEncryptDialog}
+                checked={generalForm.fields.encryptDB}
+                onClose={generalForm.handleEncryptDialog.onClose}
+                handleEncrypt={generalForm.handleEncryptDialog.handleEncrypt}
             />
 
             <DialogSaveData
@@ -82,10 +75,7 @@ const GeneralSettings = ({
 
 GeneralSettings.propTypes = {
     state: PropTypes.object.isRequired,
-    handleChange: PropTypes.func.isRequired,
-    validatePhoneNumber: PropTypes.object.isRequired,
-    handleReset: PropTypes.func.isRequired,
-    handleEncryptCheckbox: PropTypes.object.isRequired,
+    generalForm: PropTypes.object.isRequired,
     handleSaveDialog: PropTypes.object.isRequired,
     handleDisableSettings: PropTypes.object.isRequired,
 }

--- a/src/components/sections/general/general-settings.js
+++ b/src/components/sections/general/general-settings.js
@@ -10,6 +10,7 @@ import ErrorAlert from '../../alert-bar/error-alert'
 import GeneralForm from './general-form'
 
 import styles from '../../../styles/LayoutTitles.module.css'
+import DialogDisableSettings from '../../dialog/dialog-disable-settings'
 
 const GeneralSettings = ({
     state,
@@ -18,7 +19,7 @@ const GeneralSettings = ({
     handleReset,
     handleEncryptCheckbox,
     handleSaveDialog,
-    removeNamespace,
+    handleDisableSettings,
 }) => {
     return (
         <>
@@ -38,20 +39,26 @@ const GeneralSettings = ({
                 handleReset={handleReset}
                 handleEncryptCheckbox={handleEncryptCheckbox}
                 handleSaveDialog={handleSaveDialog}
-                removeNamespace={removeNamespace}
+                handleDisableSettings={handleDisableSettings}
             />
 
             <DialogEncrypt
-                openDialog={state.openDialog}
-                checked={state.encryptDB}
+                openDialog={state.openDialog.encryptDB}
+                checked={state.generalParameters.encryptDB}
                 onClose={handleEncryptCheckbox.onClose}
                 handleEncrypt={handleEncryptCheckbox.handleEncrypt}
             />
 
             <DialogSaveData
-                openDialog={state.openDialogSaveData}
+                openDialog={state.openDialog.saveData}
                 onClose={handleSaveDialog.close}
                 saveDataStore={handleSaveDialog.save}
+            />
+
+            <DialogDisableSettings
+                openDialog={state.openDialog.disableSettings}
+                onClose={handleDisableSettings.cancel}
+                disableSettings={handleDisableSettings.disableSettings}
             />
 
             <SuccessAlert
@@ -80,6 +87,7 @@ GeneralSettings.propTypes = {
     handleReset: PropTypes.func.isRequired,
     handleEncryptCheckbox: PropTypes.object.isRequired,
     handleSaveDialog: PropTypes.object.isRequired,
+    handleDisableSettings: PropTypes.object.isRequired,
 }
 
 export default GeneralSettings

--- a/src/constants/android-settings.js
+++ b/src/constants/android-settings.js
@@ -35,7 +35,7 @@ export const dataOptions = [
 ]
 
 export const maxValues = {
-    reservedValues: 50,
+    reservedValues: 500,
 }
 
 export const encryptTitles = {
@@ -46,7 +46,7 @@ export const encryptTitles = {
 export const androidSettingsDefault = {
     metadataSync: '24h',
     dataSync: '24h',
-    reservedValues: 0,
+    reservedValues: 100,
     encryptDB: false,
 }
 

--- a/src/modules/general/useGeneralForm.js
+++ b/src/modules/general/useGeneralForm.js
@@ -1,0 +1,198 @@
+import {
+    androidSettingsDefault,
+    maxValues,
+    RESERVED_VALUES,
+} from '../../constants/android-settings'
+import { useCallback, useEffect, useState } from 'react'
+import { validateNumber } from './validatePhoneNumber'
+
+const {
+    metadataSync,
+    dataSync,
+    encryptDB,
+    reservedValues,
+} = androidSettingsDefault
+
+export const useGeneralForm = ({
+    setOpenDialog,
+    setOpenErrorAlert,
+    openDialog,
+    setSubmitDataStore,
+}) => {
+    const [generalParameters, setGeneralParameters] = useState({
+        metadataSync,
+        dataSync,
+        numberSmsToSend: '',
+        numberSmsConfirmation: '',
+        reservedValues,
+        encryptDB,
+    })
+
+    const [errorNumber, setErrorNumber] = useState({
+        confirmation: false,
+        gateway: false,
+    })
+
+    const [disableSave, setDisableSave] = useState(true)
+
+    useEffect(() => {
+        setSubmitDataStore({
+            success: false,
+            error: false,
+        })
+    }, [])
+
+    const handleChange = useCallback(e => {
+        e.preventDefault()
+
+        let { value } = e.target
+
+        if (e.target.name === RESERVED_VALUES) {
+            value = Math.min(maxValues.reservedValues, parseInt(value))
+        }
+
+        setGeneralParameters({
+            ...generalParameters,
+            [e.target.name]: value,
+        })
+        setDisableSave(errorNumber.gateway || errorNumber.confirmation)
+        setSubmitDataStore({
+            success: false,
+            error: false,
+        })
+    })
+
+    /**
+     * Sets values to default
+     */
+
+    const handleReset = useCallback(() => {
+        setGeneralParameters({
+            metadataSync,
+            dataSync,
+            numberSmsToSend: '',
+            numberSmsConfirmation: '',
+            reservedValues,
+            encryptDB,
+        })
+        setOpenDialog({
+            ...openDialog,
+            encryptDB: false,
+        })
+        setDisableSave(false)
+        setSubmitDataStore({
+            success: false,
+            error: false,
+        })
+        setOpenErrorAlert(false)
+    })
+
+    /**
+     * When using checkbox for Encrypt DB should open dialog
+     * onChange: When Checkbox is checked or not opens dialog
+     * onClose: close Encrypt DB dialog
+     * handleEncrypt: Changes value for encryptDB state
+     */
+
+    const handleCheckbox = {
+        onChange: useCallback(() => {
+            setOpenDialog({
+                ...openDialog,
+                encryptDB: true,
+            })
+            setSubmitDataStore({
+                success: false,
+                error: false,
+            })
+        }),
+        onClose: useCallback(() => {
+            setOpenDialog({
+                ...openDialog,
+                encryptDB: false,
+            })
+        }),
+        handleEncrypt: useCallback(isChecked => {
+            setGeneralParameters({
+                ...generalParameters,
+                encryptDB: !isChecked,
+            })
+            setOpenDialog({
+                ...openDialog,
+                encryptDB: false,
+            })
+            setDisableSave(false)
+        }),
+    }
+
+    /**
+     * Checks if sms number or confirmation number is valid
+     */
+    const validatePhoneNumber = {
+        gatewayNumber: useCallback(() => {
+            if (
+                ![null, '', false].includes(generalParameters.numberSmsToSend)
+            ) {
+                const validInput = validateNumber(
+                    generalParameters.numberSmsToSend
+                )
+                if (!validInput) {
+                    setErrorNumber({
+                        ...errorNumber,
+                        gateway: true,
+                    })
+                    setDisableSave(true)
+                } else {
+                    setErrorNumber({
+                        ...errorNumber,
+                        gateway: false,
+                    })
+                }
+            } else {
+                setErrorNumber({
+                    ...errorNumber,
+                    gateway: false,
+                })
+            }
+        }),
+        confirmationNumber: useCallback(() => {
+            if (
+                ![null, '', false].includes(
+                    generalParameters.numberSmsConfirmation
+                )
+            ) {
+                const validInput = validateNumber(
+                    generalParameters.numberSmsConfirmation
+                )
+                if (!validInput) {
+                    setErrorNumber({
+                        ...errorNumber,
+                        confirmation: true,
+                    })
+                    setDisableSave(true)
+                } else {
+                    setErrorNumber({
+                        ...errorNumber,
+                        confirmation: false,
+                    })
+                }
+            } else {
+                setErrorNumber({
+                    ...errorNumber,
+                    confirmation: false,
+                })
+            }
+        }),
+    }
+
+    return {
+        handleChange,
+        handleReset,
+        handleCheckbox,
+        validatePhoneNumber,
+        generalParameters,
+        setGeneralParameters,
+        errorNumber,
+        disableSave,
+        setDisableSave,
+    }
+}

--- a/src/modules/general/useSaveGeneralSettings.js
+++ b/src/modules/general/useSaveGeneralSettings.js
@@ -1,0 +1,86 @@
+import api from '../../utils/api'
+import { GENERAL_SETTINGS, NAMESPACE } from '../../constants/data-store'
+import { useCallback } from 'react'
+
+export const useSaveGeneralSettings = ({
+    generalParameters,
+    openDialog,
+    setOpenDialog,
+    setDisableSave,
+    setSubmitDataStore,
+}) => {
+    /**
+     * Handle update api method to save settings in dataStore also shows alertBar for success and error
+     * */
+    const saveDataApi = data => {
+        api.updateValue(NAMESPACE, GENERAL_SETTINGS, data)
+            .then(() => {
+                setSubmitDataStore({
+                    success: true,
+                    error: false,
+                })
+            })
+            .catch(e => {
+                console.error(e)
+                setSubmitDataStore({
+                    success: false,
+                    error: true,
+                })
+            })
+    }
+
+    /**
+     * Updates Settings calling update api,
+     * check if gateway and confirmation number are not empty
+     * Prevent null console warning
+     */
+    const submitData = () => {
+        const androidData = {
+            metadataSync: generalParameters.metadataSync,
+            dataSync: generalParameters.dataSync,
+            reservedValues: generalParameters.reservedValues,
+            encryptDB: generalParameters.encryptDB,
+            lastUpdated: new Date().toJSON(),
+        }
+
+        if (
+            !['', null, undefined].includes(generalParameters.numberSmsToSend)
+        ) {
+            androidData.numberSmsToSend = generalParameters.numberSmsToSend
+        }
+
+        if (
+            !['', null, undefined].includes(
+                generalParameters.numberSmsConfirmation
+            )
+        ) {
+            androidData.numberSmsConfirmation =
+                generalParameters.numberSmsConfirmation
+        }
+
+        saveDataApi(androidData)
+    }
+
+    return {
+        open: useCallback(() => {
+            setOpenDialog({
+                ...openDialog,
+                saveData: true,
+            })
+        }),
+        close: useCallback(() => {
+            setOpenDialog({
+                ...openDialog,
+                saveData: false,
+            })
+        }),
+        save: useCallback(() => {
+            submitData()
+            setOpenDialog({
+                ...openDialog,
+                saveData: false,
+            })
+            setDisableSave(true)
+        }),
+    }
+}

--- a/src/modules/general/useSaveGeneralSettings.js
+++ b/src/modules/general/useSaveGeneralSettings.js
@@ -1,14 +1,14 @@
 import api from '../../utils/api'
 import { GENERAL_SETTINGS, NAMESPACE } from '../../constants/data-store'
-import { useCallback } from 'react'
+import { useState } from 'react'
 
-export const useSaveGeneralSettings = ({
-    generalParameters,
-    openDialog,
-    setOpenDialog,
-    setDisableSave,
-    setSubmitDataStore,
-}) => {
+export const useSaveGeneralSettings = ({ form, setSubmitDataStore }) => {
+    const { fields, setDisableSave } = form
+    const [openDialog, setOpenDialog] = useState({
+        saveData: false,
+        disableSettings: false,
+    })
+
     /**
      * Handle update api method to save settings in dataStore also shows alertBar for success and error
      * */
@@ -36,51 +36,48 @@ export const useSaveGeneralSettings = ({
      */
     const submitData = () => {
         const androidData = {
-            metadataSync: generalParameters.metadataSync,
-            dataSync: generalParameters.dataSync,
-            reservedValues: generalParameters.reservedValues,
-            encryptDB: generalParameters.encryptDB,
+            metadataSync: fields.metadataSync,
+            dataSync: fields.dataSync,
+            reservedValues: fields.reservedValues,
+            encryptDB: fields.encryptDB,
             lastUpdated: new Date().toJSON(),
         }
 
-        if (
-            !['', null, undefined].includes(generalParameters.numberSmsToSend)
-        ) {
-            androidData.numberSmsToSend = generalParameters.numberSmsToSend
+        if (!['', null, undefined].includes(fields.numberSmsToSend)) {
+            androidData.numberSmsToSend = fields.numberSmsToSend
         }
 
-        if (
-            !['', null, undefined].includes(
-                generalParameters.numberSmsConfirmation
-            )
-        ) {
-            androidData.numberSmsConfirmation =
-                generalParameters.numberSmsConfirmation
+        if (!['', null, undefined].includes(fields.numberSmsConfirmation)) {
+            androidData.numberSmsConfirmation = fields.numberSmsConfirmation
         }
 
         saveDataApi(androidData)
     }
 
     return {
-        open: useCallback(() => {
-            setOpenDialog({
-                ...openDialog,
-                saveData: true,
-            })
-        }),
-        close: useCallback(() => {
-            setOpenDialog({
-                ...openDialog,
-                saveData: false,
-            })
-        }),
-        save: useCallback(() => {
-            submitData()
-            setOpenDialog({
-                ...openDialog,
-                saveData: false,
-            })
-            setDisableSave(true)
-        }),
+        handleSaveDataDialog: {
+            open: () => {
+                setOpenDialog({
+                    ...openDialog,
+                    saveData: true,
+                })
+            },
+            close: () => {
+                setOpenDialog({
+                    ...openDialog,
+                    saveData: false,
+                })
+            },
+            save: () => {
+                submitData()
+                setOpenDialog({
+                    ...openDialog,
+                    saveData: false,
+                })
+                setDisableSave(true)
+            },
+        },
+        setOpenDialog,
+        openDialog,
     }
 }

--- a/src/modules/populateDefaultSettings.js
+++ b/src/modules/populateDefaultSettings.js
@@ -1,0 +1,31 @@
+import { programSettingsDefault } from '../constants/program-settings'
+import { dataSetSettingsDefault } from '../constants/data-set-settings'
+
+export const DEFAULT_PROGRAM = 'DEFAULT_PROGRAM'
+export const DEFAULT_DATASET = 'DEFAULT_DATASET'
+
+export const populateObject = type => {
+    let object = {}
+    switch (type) {
+        case DEFAULT_PROGRAM:
+            object = {
+                settingDownload: programSettingsDefault.settingDownload,
+                teiDownload: programSettingsDefault.teiDownload,
+                enrollmentDownload: programSettingsDefault.enrollmentDownload,
+                enrollmentDateDownload:
+                    programSettingsDefault.enrollmentDateDownload,
+                updateDownload: programSettingsDefault.updateDownload,
+                eventsDownload: programSettingsDefault.eventsDownload,
+                eventDateDownload: programSettingsDefault.eventDateDownload,
+            }
+            break
+        case DEFAULT_DATASET:
+            object = {
+                periodDSDownload: dataSetSettingsDefault.periodDSDownload,
+            }
+            break
+        default:
+            break
+    }
+    return object
+}

--- a/src/utils/useNavigation.js
+++ b/src/utils/useNavigation.js
@@ -1,0 +1,14 @@
+import { useHistory } from 'react-router-dom'
+
+export const useNavigation = () => {
+    const history = useHistory()
+
+    return {
+        reloadPage: () => {
+            history.go(0)
+        },
+        navigateTo: path => {
+            history.push(path)
+        },
+    }
+}


### PR DESCRIPTION
This PR has:

- Add `useHistory` from react-router-dom, to access navigation history.
- Switch `android-settings-container` and layout from class to functional component, to use `useHistory` hook.
- Add a fallback route to catch no match routes. Page not found component, in case the URL is not part of the routes.
- Change Disable all settings button position, add dialog to ensure knowledge of "Disable" action.
- Fix reserved values constants.


**Fixing bug**:
The fix/implement is related to a bug found on the "Disable settings" workflow. When clicking on disable settings the namespace and keys should be deleted from datastore and after that because there is no namespace the workflow starts again from first setup dialog.
Bug: When the user clicked on Disable Settings, they were afterward redirected to a different page where the app is not located


**NOTE**: PR #46 also tries to solve the same bug but using hashHistory and changing HashRouter to Router