### PR TITLE
fix: change delete namespace function

### DIFF
--- a/src/components/sections/general/android-settings-container.js
+++ b/src/components/sections/general/android-settings-container.js
@@ -70,7 +70,7 @@ const AndroidSettingsContainer = () => {
             })
         },
         disableSettings: () => {
-            removeNamespaceFromDataStore()
+            removeNamespace()
                 .then(() => {
                     console.info('remove namespace')
                     reloadPage()
@@ -79,21 +79,6 @@ const AndroidSettingsContainer = () => {
                     console.error(e)
                 })
         },
-    }
-
-    /**
-     * Remove namespaces and keynames
-     * */
-
-    const removeNamespaceFromDataStore = () => {
-        removeNamespace()
-            .then(() => {
-                console.info('remove namespace')
-                location.replace('/')
-            })
-            .catch(e => {
-                console.error(e)
-            })
     }
 
     if (loading === true) {

--- a/src/components/sections/general/android-settings-container.js
+++ b/src/components/sections/general/android-settings-container.js
@@ -7,6 +7,7 @@ import { apiLoadGeneralSettings } from '../../../modules/general/apiLoadSettings
 import { useNavigation } from '../../../utils/useNavigation'
 import { useGeneralForm } from '../../../modules/general/useGeneralForm'
 import { useSaveGeneralSettings } from '../../../modules/general/useSaveGeneralSettings'
+import { removeNamespace } from '../../../modules/general/removeNamespace'
 
 const AndroidSettingsContainer = () => {
     const [submitDataStore, setSubmitDataStore] = useState({
@@ -69,7 +70,7 @@ const AndroidSettingsContainer = () => {
             })
         },
         disableSettings: () => {
-            removeNamespace()
+            removeNamespaceFromDataStore()
                 .then(() => {
                     console.info('remove namespace')
                     reloadPage()
@@ -84,7 +85,7 @@ const AndroidSettingsContainer = () => {
      * Remove namespaces and keynames
      * */
 
-    const removeNamespace = () => {
+    const removeNamespaceFromDataStore = () => {
         removeNamespace()
             .then(() => {
                 console.info('remove namespace')


### PR DESCRIPTION
This PR deletes an extra function for remove namespace. 

This bug was found after merging the previous PR, an extra function was left and that made the app crash.