### PR TITLE
fix: [DHIS2-9302] change labels metadata and data options

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,13 +5,10 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-06-18T06:56:04.402Z\n"
-"PO-Revision-Date: 2020-06-18T06:56:04.402Z\n"
+"POT-Creation-Date: 2020-08-22T02:50:32.289Z\n"
+"PO-Revision-Date: 2020-08-22T02:50:32.289Z\n"
 
 msgid "Failed to get data from Data Store"
-msgstr ""
-
-msgid "Error when saving data"
 msgstr ""
 
 msgid "Settings were successfully saved"
@@ -72,6 +69,9 @@ msgstr ""
 msgid ""
 "Any settings or configuration on a user's device will be overwritten by "
 "settings applied here."
+msgstr ""
+
+msgid "You don't have the authority to set up the android settings to this instance"
 msgstr ""
 
 msgid ""

--- a/src/constants/android-settings.js
+++ b/src/constants/android-settings.js
@@ -3,34 +3,34 @@ import i18n from '@dhis2/d2-i18n'
 export const metadataOptions = [
     {
         value: '24h',
-        label: '24h',
+        label: '1 Day',
     },
     {
         value: '7d',
-        label: '7d',
+        label: '1 Week',
     },
 ]
 
 export const dataOptions = [
     {
         value: '30m',
-        label: '30m',
+        label: '30 Minutes',
     },
     {
         value: '1h',
-        label: '1h',
+        label: '1 Hour',
     },
     {
         value: '6h',
-        label: '6h',
+        label: '6 Hours',
     },
     {
         value: '12h',
-        label: '12h',
+        label: '12 Hours',
     },
     {
         value: '24h',
-        label: '24h',
+        label: '1 Day',
     },
 ]
 


### PR DESCRIPTION
**Description**

The app has different labels for data and metadata sync options. 
Sync options should be the same as in the app.

[jira issue DHIS2-9302](https://jira.dhis2.org/browse/DHIS2-9302)

**Solution description**
Change labels for sync options:

Data options:

Webapp | APP
-- | --
24h | 1 Day
7d | 1 Week


Metadata options:

Webapp | APP
-- | --
30m | 30 Minutes
1h | 1 Hour
6h | 6h
12h | 12h
24h | 1 Day

