### PR TITLE
fix: [DHIS2-9301] add Manual option to sync

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,13 +5,10 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-06-18T06:56:04.402Z\n"
-"PO-Revision-Date: 2020-06-18T06:56:04.402Z\n"
+"POT-Creation-Date: 2020-08-22T21:37:33.990Z\n"
+"PO-Revision-Date: 2020-08-22T21:37:33.990Z\n"
 
 msgid "Failed to get data from Data Store"
-msgstr ""
-
-msgid "Error when saving data"
 msgstr ""
 
 msgid "Settings were successfully saved"
@@ -72,6 +69,9 @@ msgstr ""
 msgid ""
 "Any settings or configuration on a user's device will be overwritten by "
 "settings applied here."
+msgstr ""
+
+msgid "You don't have the authority to set up the android settings to this instance"
 msgstr ""
 
 msgid ""

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-08-22T21:37:33.990Z\n"
-"PO-Revision-Date: 2020-08-22T21:37:33.990Z\n"
+"POT-Creation-Date: 2020-09-12T01:09:55.979Z\n"
+"PO-Revision-Date: 2020-09-12T01:09:55.979Z\n"
 
 msgid "Failed to get data from Data Store"
 msgstr ""
@@ -83,6 +83,21 @@ msgid "Exit, do not apply settings"
 msgstr ""
 
 msgid "Set defaults and save"
+msgstr ""
+
+msgid "Select Manual option"
+msgstr ""
+
+msgid ""
+"By selecting Manual there will NOT be any AUTOMATIC SYNCHRONIZATION of "
+"data. Your users will need to sync manually for data to be sent to the "
+"server."
+msgstr ""
+
+msgid "Do you want to select this option?"
+msgstr ""
+
+msgid "Yes"
 msgstr ""
 
 msgid "Save in DataStore"
@@ -162,6 +177,14 @@ msgstr ""
 msgid "These settings apply to all Android users."
 msgstr ""
 
+msgid "Manual options"
+msgstr ""
+
+msgid ""
+"Manual options for data and metadata sync are only available from android "
+"app version 2.3.0 onwards."
+msgstr ""
+
 msgid "Summary Settings"
 msgstr ""
 
@@ -195,6 +218,9 @@ msgstr ""
 msgid ""
 "You have unsaved changes, if you leave you will lose your changes. Are you "
 "sure you want to leave?"
+msgstr ""
+
+msgid "Manual"
 msgstr ""
 
 msgid "Maximum number of periods to download data sets for"

--- a/src/components/dialog/dialog-manual-alert.js
+++ b/src/components/dialog/dialog-manual-alert.js
@@ -1,0 +1,47 @@
+import React from 'react'
+
+import {
+    Modal,
+    ModalTitle,
+    ModalContent,
+    ModalActions,
+    ButtonStrip,
+    Button,
+} from '@dhis2/ui'
+import i18n from '@dhis2/d2-i18n'
+import PropTypes from '@dhis2/prop-types'
+
+const DialogManualAlert = ({ openDialog, onClose, chooseOption }) => (
+    <>
+        {openDialog && (
+            <Modal small onClose={onClose} position="middle">
+                <ModalTitle>{i18n.t('Select Manual option')}</ModalTitle>
+                <ModalContent>
+                    <p>
+                        {i18n.t(
+                            'By selecting Manual there will NOT be any AUTOMATIC SYNCHRONIZATION of data. Your users will need to sync manually for data to be sent to the server.'
+                        )}
+                    </p>
+
+                    <p>{i18n.t('Do you want to select this option?')}</p>
+                </ModalContent>
+                <ModalActions>
+                    <ButtonStrip end>
+                        <Button onClick={onClose}>{i18n.t('Cancel')}</Button>
+                        <Button onClick={chooseOption} primary>
+                            {i18n.t('Yes')}
+                        </Button>
+                    </ButtonStrip>
+                </ModalActions>
+            </Modal>
+        )}
+    </>
+)
+
+DialogManualAlert.propTypes = {
+    openDialog: PropTypes.bool.isRequired,
+    onClose: PropTypes.func.isRequired,
+    chooseOption: PropTypes.func.isRequired,
+}
+
+export default DialogManualAlert

--- a/src/components/notice-alert.js
+++ b/src/components/notice-alert.js
@@ -1,0 +1,19 @@
+import React from 'react'
+import { NoticeBox } from '@dhis2/ui'
+
+const NoticeAlert = ({ title, notice }) => (
+    <div>
+        <NoticeBox title={title} warning>
+            {notice}
+        </NoticeBox>
+        <style jsx>
+            {`
+                 {
+                    margin-bottom: 20px;
+                }
+            `}
+        </style>
+    </div>
+)
+
+export default NoticeAlert

--- a/src/components/sections/general/general-settings.js
+++ b/src/components/sections/general/general-settings.js
@@ -11,6 +11,8 @@ import GeneralForm from './general-form'
 
 import styles from '../../../styles/LayoutTitles.module.css'
 import DialogDisableSettings from '../../dialog/dialog-disable-settings'
+import NoticeAlert from '../../notice-alert'
+import DialogManualAlert from '../../dialog/dialog-manual-alert'
 
 const GeneralSettings = ({
     state,
@@ -29,10 +31,23 @@ const GeneralSettings = ({
                 </p>
             </div>
 
+            <NoticeAlert
+                title={i18n.t('Manual options')}
+                notice={i18n.t(
+                    'Manual options for data and metadata sync are only available from android app version 2.3.0 onwards.'
+                )}
+            />
+
             <GeneralForm
                 handleForm={generalForm}
                 handleSaveDialog={handleSaveDialog}
                 handleDisableSettings={handleDisableSettings}
+            />
+
+            <DialogManualAlert
+                openDialog={generalForm.manualAlertDialog.open}
+                chooseOption={generalForm.handleManualAlert.save}
+                onClose={generalForm.handleManualAlert.close}
             />
 
             <DialogEncrypt

--- a/src/constants/android-settings.js
+++ b/src/constants/android-settings.js
@@ -9,6 +9,10 @@ export const metadataOptions = [
         value: '7d',
         label: '7d',
     },
+    {
+        value: 'manual',
+        label: 'Manual',
+    },
 ]
 
 export const dataOptions = [
@@ -31,6 +35,10 @@ export const dataOptions = [
     {
         value: '24h',
         label: '24h',
+    },
+    {
+        value: 'manual',
+        label: 'Manual',
     },
 ]
 

--- a/src/constants/android-settings.js
+++ b/src/constants/android-settings.js
@@ -1,5 +1,10 @@
 import i18n from '@dhis2/d2-i18n'
 
+export const RESERVED_VALUES = 'reservedValues'
+export const MANUAL = 'manual'
+export const SMS_TO_SEND = 'numberSmsToSend'
+export const SMS_CONFIRMATION = 'numberSmsConfirmation'
+
 export const metadataOptions = [
     {
         value: '24h',
@@ -10,7 +15,7 @@ export const metadataOptions = [
         label: i18n.t('1 Week'),
     },
     {
-        value: 'manual',
+        value: MANUAL,
         label: i18n.t('Manual'),
     },
 ]
@@ -37,7 +42,7 @@ export const dataOptions = [
         label: i18n.t('1 Day'),
     },
     {
-        value: 'manual',
+        value: MANUAL,
         label: i18n.t('Manual'),
     },
 ]
@@ -57,11 +62,6 @@ export const androidSettingsDefault = {
     reservedValues: 100,
     encryptDB: false,
 }
-
-export const RESERVED_VALUES = 'reservedValues'
-export const manual = 'manual'
-export const SMS_TO_SEND = 'numberSmsToSend'
-export const SMS_CONFIRMATION = 'numberSmsConfirmation'
 
 export const generalSettingsFormSections = {
     metadata: {

--- a/src/constants/android-settings.js
+++ b/src/constants/android-settings.js
@@ -11,7 +11,7 @@ export const metadataOptions = [
     },
     {
         value: 'manual',
-        label: 'Manual',
+        label: i18n.t('Manual'),
     },
 ]
 
@@ -38,7 +38,7 @@ export const dataOptions = [
     },
     {
         value: 'manual',
-        label: 'Manual',
+        label: i18n.t('Manual'),
     },
 ]
 
@@ -59,3 +59,4 @@ export const androidSettingsDefault = {
 }
 
 export const RESERVED_VALUES = 'reservedValues'
+export const manual = 'manual'

--- a/src/modules/general/useGeneralForm.js
+++ b/src/modules/general/useGeneralForm.js
@@ -33,29 +33,11 @@ export const useGeneralForm = ({ setSubmitDataStore }) => {
 
     const onChange = e => {
         let { value } = e
-        if (value === manual) {
-            handleManualAlert.open(value, e.name)
-        } else {
-            if (e.name === RESERVED_VALUES) {
-                value = Math.min(maxValues.reservedValues, parseInt(value))
-
-                setFields({ ...fields, [e.name]: value })
-                setDisableSave(
-                    errorNumber.numberSmsToSend ||
-                        errorNumber.numberSmsConfirmation
-                )
-                setSubmitDataStore({
-                    success: false,
-                    error: false,
-                })
-            } else if (e.name === SMS_TO_SEND || e.name === SMS_CONFIRMATION) {
-                validatePhoneNumber(e)
-            }
+        if (e.name === RESERVED_VALUES) {
+            value = value <= 0 ? 0 : Math.min(maxValues.reservedValues, value)
         }
-    }
 
-    const onChangeSelect = (e, name) => {
-        setFields({ ...fields, [name]: e.selected })
+        setFields({ ...fields, [e.name]: value })
         setDisableSave(
             errorNumber.numberSmsToSend || errorNumber.numberSmsConfirmation
         )
@@ -63,6 +45,25 @@ export const useGeneralForm = ({ setSubmitDataStore }) => {
             success: false,
             error: false,
         })
+
+        if (e.name === SMS_TO_SEND || e.name === SMS_CONFIRMATION) {
+            validatePhoneNumber(e)
+        }
+    }
+
+    const onChangeSelect = (e, name) => {
+        if (e.selected === manual) {
+            handleManualAlert.open(e.selected, name)
+        } else {
+            setFields({ ...fields, [name]: e.selected })
+            setDisableSave(
+                errorNumber.numberSmsToSend || errorNumber.numberSmsConfirmation
+            )
+            setSubmitDataStore({
+                success: false,
+                error: false,
+            })
+        }
     }
 
     /**
@@ -192,7 +193,6 @@ export const useGeneralForm = ({ setSubmitDataStore }) => {
             name,
             selected: fields[name],
             disabled: fields.disableAll,
-            onChange,
         }),
         getCheckbox: name => ({
             name,

--- a/src/modules/general/useGeneralForm.js
+++ b/src/modules/general/useGeneralForm.js
@@ -1,6 +1,6 @@
 import {
     androidSettingsDefault,
-    manual,
+    MANUAL,
     maxValues,
     RESERVED_VALUES,
     SMS_CONFIRMATION,
@@ -52,7 +52,7 @@ export const useGeneralForm = ({ setSubmitDataStore }) => {
     }
 
     const onChangeSelect = (e, name) => {
-        if (e.selected === manual) {
+        if (e.selected === MANUAL) {
             handleManualAlert.open(e.selected, name)
         } else {
             setFields({ ...fields, [name]: e.selected })

--- a/src/modules/general/useGeneralForm.js
+++ b/src/modules/general/useGeneralForm.js
@@ -1,5 +1,6 @@
 import {
     androidSettingsDefault,
+    manual,
     maxValues,
     RESERVED_VALUES,
 } from '../../constants/android-settings'
@@ -18,6 +19,10 @@ export const useGeneralForm = ({ setSubmitDataStore }) => {
         numberSmsToSend: '',
         numberSmsConfirmation: '',
     })
+    const [manualAlertDialog, setManualAlert] = useState({
+        open: false,
+        selection: {},
+    })
 
     const setInitialData = settings => {
         setFields(settings)
@@ -29,16 +34,50 @@ export const useGeneralForm = ({ setSubmitDataStore }) => {
 
         let { value } = e.target
 
-        if (e.target.name === RESERVED_VALUES) {
-            value = Math.min(maxValues.reservedValues, parseInt(value))
-        }
+        if (value === manual) {
+            handleManualAlert.open(value, e.target.name)
+        } else {
+            if (e.target.name === RESERVED_VALUES) {
+                value = Math.min(maxValues.reservedValues, parseInt(value))
+            }
 
-        setFields({ ...fields, [e.target.name]: value })
-        setDisableSave(errorNumber.gateway || errorNumber.confirmation)
-        setSubmitDataStore({
-            success: false,
-            error: false,
-        })
+            setFields({ ...fields, [e.target.name]: value })
+            setDisableSave(errorNumber.gateway || errorNumber.confirmation)
+            setSubmitDataStore({
+                success: false,
+                error: false,
+            })
+        }
+    }
+
+    /**
+     * When Manual option is selected, an alert (dialog) should pop up
+     * */
+    const handleManualAlert = {
+        open: (selection, name) => {
+            setManualAlert({
+                selection: { name, value: selection },
+                open: true,
+            })
+        },
+        close: () => {
+            setManualAlert({ ...manualAlertDialog, open: false })
+        },
+        save: () => {
+            const { name, value } = manualAlertDialog.selection
+            setFields({ ...fields, [name]: value })
+            setDisableSave(
+                errorNumber.numberSmsToSend || errorNumber.numberSmsConfirmation
+            )
+            setSubmitDataStore({
+                success: false,
+                error: false,
+            })
+            setManualAlert({
+                open: false,
+                selection: {},
+            })
+        },
     }
 
     const onCheckboxChange = event => {
@@ -115,6 +154,8 @@ export const useGeneralForm = ({ setSubmitDataStore }) => {
         disableSave,
         setDisableSave,
         handleEncryptDialog,
+        handleManualAlert,
+        manualAlertDialog,
         getInput: name => ({
             name,
             value: fields[name],


### PR DESCRIPTION
Add manual option to Sync Metadata and Data

- when clicking on the manual option, an alert dialog should pop up
- if click on OK, the manual option will be selected
- if click on Cancel, the previous option will remain selected
- This option only available from android app version 2.3.0 onwards

**Alert Dialog Text:** 
```
By selecting Manual there will NOT be any AUTOMATIC SYNCHRONIZATION of data. Your users will need to sync manually for data to be sent to the server. Do you want to select this option?'
```

[JIRA DHIS2 9301](https://jira.dhis2.org/browse/DHIS2-9301)
