### PR TITLE
fix: manual dialog text

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-10-30T17:09:59.408Z\n"
-"PO-Revision-Date: 2020-10-30T17:09:59.408Z\n"
+"POT-Creation-Date: 2020-12-10T22:46:28.994Z\n"
+"PO-Revision-Date: 2020-12-10T22:46:28.994Z\n"
 
 msgid "Failed to get data from Data Store"
 msgstr ""
@@ -90,8 +90,7 @@ msgstr ""
 
 msgid ""
 "By selecting Manual there will NOT be any AUTOMATIC SYNCHRONIZATION of "
-"data. Your users will need to sync manually for data to be sent to the "
-"server."
+"{{type}}. Your users will need to download the {{type}} manually."
 msgstr ""
 
 msgid "Do you want to select this option?"
@@ -134,36 +133,6 @@ msgid "Name"
 msgstr ""
 
 msgid "Number of Periods"
-msgstr ""
-
-msgid "How often should metadata sync?"
-msgstr ""
-
-msgid "How often should data sync?"
-msgstr ""
-
-msgid "SMS Gateway phone number"
-msgstr ""
-
-msgid "Must start with + and be at least 4 characters long."
-msgstr ""
-
-msgid "SMS Result Sender phone number"
-msgstr ""
-
-msgid "Reserved values downloaded per TEI attribute"
-msgstr ""
-
-msgid "Encrypt device database"
-msgstr ""
-
-msgid ""
-"Encrypt all data stored on device. Data can be lost if there are problems "
-"with an encrypted database. This will not affect the DHIS2 database stored "
-"on an external server."
-msgstr ""
-
-msgid "This will disable and remove all General, Program and Data set settings."
 msgstr ""
 
 msgid "General download sync settings"
@@ -233,9 +202,39 @@ msgstr ""
 msgid "12 Hours"
 msgstr ""
 
+msgid "How often should metadata sync?"
+msgstr ""
+
+msgid "How often should data sync?"
+msgstr ""
+
+msgid "SMS Gateway phone number"
+msgstr ""
+
+msgid "Must start with + and be at least 4 characters long."
+msgstr ""
+
 msgid ""
 "This phone number is not valid. Must start with + and be at least 4 "
 "characters long."
+msgstr ""
+
+msgid "SMS Result Sender phone number"
+msgstr ""
+
+msgid "Reserved values downloaded per TEI attribute"
+msgstr ""
+
+msgid "Encrypt device database"
+msgstr ""
+
+msgid ""
+"Encrypt all data stored on device. Data can be lost if there are problems "
+"with an encrypted database. This will not affect the DHIS2 database stored "
+"on an external server."
+msgstr ""
+
+msgid "This will disable and remove all General, Program and Data set settings."
 msgstr ""
 
 msgid "Maximum number of periods to download data sets for"

--- a/src/components/dialog/dialog-manual-alert.js
+++ b/src/components/dialog/dialog-manual-alert.js
@@ -10,38 +10,52 @@ import {
 } from '@dhis2/ui'
 import i18n from '@dhis2/d2-i18n'
 import PropTypes from '@dhis2/prop-types'
+import { DATA, METADATA, METADATA_SYNC } from '../../constants/android-settings'
 
-const DialogManualAlert = ({ openDialog, onClose, chooseOption }) => (
-    <>
-        {openDialog && (
-            <Modal small onClose={onClose} position="middle">
-                <ModalTitle>{i18n.t('Select Manual option')}</ModalTitle>
-                <ModalContent>
-                    <p>
-                        {i18n.t(
-                            'By selecting Manual there will NOT be any AUTOMATIC SYNCHRONIZATION of data. Your users will need to sync manually for data to be sent to the server.'
-                        )}
-                    </p>
+const DialogManualAlert = ({
+    openDialog,
+    onClose,
+    chooseOption,
+    manualOptionType,
+}) => {
+    const type = manualOptionType === METADATA_SYNC ? METADATA : DATA
 
-                    <p>{i18n.t('Do you want to select this option?')}</p>
-                </ModalContent>
-                <ModalActions>
-                    <ButtonStrip end>
-                        <Button onClick={onClose}>{i18n.t('Cancel')}</Button>
-                        <Button onClick={chooseOption} primary>
-                            {i18n.t('Yes')}
-                        </Button>
-                    </ButtonStrip>
-                </ModalActions>
-            </Modal>
-        )}
-    </>
-)
+    return (
+        <>
+            {openDialog && (
+                <Modal small onClose={onClose} position="middle">
+                    <ModalTitle>{i18n.t('Select Manual option')}</ModalTitle>
+                    <ModalContent>
+                        <p>
+                            {i18n.t(
+                                'By selecting Manual there will NOT be any AUTOMATIC SYNCHRONIZATION of {{type}}. Your users will need to download the {{type}} manually.',
+                                { type }
+                            )}
+                        </p>
+
+                        <p>{i18n.t('Do you want to select this option?')}</p>
+                    </ModalContent>
+                    <ModalActions>
+                        <ButtonStrip end>
+                            <Button onClick={onClose}>
+                                {i18n.t('Cancel')}
+                            </Button>
+                            <Button onClick={chooseOption} primary>
+                                {i18n.t('Yes')}
+                            </Button>
+                        </ButtonStrip>
+                    </ModalActions>
+                </Modal>
+            )}
+        </>
+    )
+}
 
 DialogManualAlert.propTypes = {
     openDialog: PropTypes.bool.isRequired,
     onClose: PropTypes.func.isRequired,
     chooseOption: PropTypes.func.isRequired,
+    manualOptionType: PropTypes.string,
 }
 
 export default DialogManualAlert

--- a/src/components/sections/general/general-settings.js
+++ b/src/components/sections/general/general-settings.js
@@ -47,6 +47,7 @@ const GeneralSettings = ({
             openDialog={generalForm.manualAlertDialog.open}
             chooseOption={generalForm.handleManualAlert.save}
             onClose={generalForm.handleManualAlert.close}
+            manualOptionType={generalForm.manualAlertDialog.selection.name}
         />
 
         <DialogEncrypt

--- a/src/constants/android-settings.js
+++ b/src/constants/android-settings.js
@@ -4,6 +4,9 @@ export const RESERVED_VALUES = 'reservedValues'
 export const MANUAL = 'manual'
 export const SMS_TO_SEND = 'numberSmsToSend'
 export const SMS_CONFIRMATION = 'numberSmsConfirmation'
+export const METADATA_SYNC = 'metadataSync'
+export const METADATA = 'metadata'
+export const DATA = 'data'
 
 export const metadataOptions = [
     {


### PR DESCRIPTION
Change Manual dialog's text to: 
"By selecting Manual there will NOT be any AUTOMATIC SYNCHRONIZATION of metadata. your users will need to download the metadata manually. "


The dialog should say "metadata" or "data"