### PR TITLE
feat: Migrate Material design components to UI library 1.1 version

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-10-30T17:09:59.408Z\n"
-"PO-Revision-Date: 2020-10-30T17:09:59.408Z\n"
+"POT-Creation-Date: 2020-12-10T22:46:28.994Z\n"
+"PO-Revision-Date: 2020-12-10T22:46:28.994Z\n"
 
 msgid "Failed to get data from Data Store"
 msgstr ""
@@ -90,8 +90,7 @@ msgstr ""
 
 msgid ""
 "By selecting Manual there will NOT be any AUTOMATIC SYNCHRONIZATION of "
-"data. Your users will need to sync manually for data to be sent to the "
-"server."
+"{{type}}. Your users will need to download the {{type}} manually."
 msgstr ""
 
 msgid "Do you want to select this option?"
@@ -134,36 +133,6 @@ msgid "Name"
 msgstr ""
 
 msgid "Number of Periods"
-msgstr ""
-
-msgid "How often should metadata sync?"
-msgstr ""
-
-msgid "How often should data sync?"
-msgstr ""
-
-msgid "SMS Gateway phone number"
-msgstr ""
-
-msgid "Must start with + and be at least 4 characters long."
-msgstr ""
-
-msgid "SMS Result Sender phone number"
-msgstr ""
-
-msgid "Reserved values downloaded per TEI attribute"
-msgstr ""
-
-msgid "Encrypt device database"
-msgstr ""
-
-msgid ""
-"Encrypt all data stored on device. Data can be lost if there are problems "
-"with an encrypted database. This will not affect the DHIS2 database stored "
-"on an external server."
-msgstr ""
-
-msgid "This will disable and remove all General, Program and Data set settings."
 msgstr ""
 
 msgid "General download sync settings"
@@ -233,9 +202,39 @@ msgstr ""
 msgid "12 Hours"
 msgstr ""
 
+msgid "How often should metadata sync?"
+msgstr ""
+
+msgid "How often should data sync?"
+msgstr ""
+
+msgid "SMS Gateway phone number"
+msgstr ""
+
+msgid "Must start with + and be at least 4 characters long."
+msgstr ""
+
 msgid ""
 "This phone number is not valid. Must start with + and be at least 4 "
 "characters long."
+msgstr ""
+
+msgid "SMS Result Sender phone number"
+msgstr ""
+
+msgid "Reserved values downloaded per TEI attribute"
+msgstr ""
+
+msgid "Encrypt device database"
+msgstr ""
+
+msgid ""
+"Encrypt all data stored on device. Data can be lost if there are problems "
+"with an encrypted database. This will not affect the DHIS2 database stored "
+"on an external server."
+msgstr ""
+
+msgid "This will disable and remove all General, Program and Data set settings."
 msgstr ""
 
 msgid "Maximum number of periods to download data sets for"

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-10-08T23:47:41.991Z\n"
-"PO-Revision-Date: 2020-10-08T23:47:41.991Z\n"
+"POT-Creation-Date: 2020-10-21T15:10:29.336Z\n"
+"PO-Revision-Date: 2020-10-21T15:10:29.336Z\n"
 
 msgid "Failed to get data from Data Store"
 msgstr ""
@@ -103,6 +103,9 @@ msgstr ""
 msgid "Add/Save"
 msgstr ""
 
+msgid "Reset all values to default"
+msgstr ""
+
 msgid "404 Page not found."
 msgstr ""
 
@@ -127,11 +130,6 @@ msgstr ""
 msgid "SMS Gateway phone number"
 msgstr ""
 
-msgid ""
-"This phone number is not valid. Must start with + and be at least 4 "
-"characters long."
-msgstr ""
-
 msgid "Must start with + and be at least 4 characters long."
 msgstr ""
 
@@ -151,9 +149,6 @@ msgid ""
 msgstr ""
 
 msgid "This will disable and remove all General, Program and Data set settings."
-msgstr ""
-
-msgid "Reset all values to default"
 msgstr ""
 
 msgid "General download sync settings"
@@ -198,6 +193,29 @@ msgstr ""
 msgid ""
 "You have unsaved changes, if you leave you will lose your changes. Are you "
 "sure you want to leave?"
+msgstr ""
+
+msgid "1 Day"
+msgstr ""
+
+msgid "1 Week"
+msgstr ""
+
+msgid "30 Minutes"
+msgstr ""
+
+msgid "1 Hour"
+msgstr ""
+
+msgid "6 Hours"
+msgstr ""
+
+msgid "12 Hours"
+msgstr ""
+
+msgid ""
+"This phone number is not valid. Must start with + and be at least 4 "
+"characters long."
 msgstr ""
 
 msgid "Maximum number of periods to download data sets for"

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,13 +5,10 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-06-18T06:56:04.402Z\n"
-"PO-Revision-Date: 2020-06-18T06:56:04.402Z\n"
+"POT-Creation-Date: 2020-08-22T02:50:32.289Z\n"
+"PO-Revision-Date: 2020-08-22T02:50:32.289Z\n"
 
 msgid "Failed to get data from Data Store"
-msgstr ""
-
-msgid "Error when saving data"
 msgstr ""
 
 msgid "Settings were successfully saved"
@@ -72,6 +69,9 @@ msgstr ""
 msgid ""
 "Any settings or configuration on a user's device will be overwritten by "
 "settings applied here."
+msgstr ""
+
+msgid "You don't have the authority to set up the android settings to this instance"
 msgstr ""
 
 msgid ""

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-10-21T15:10:29.336Z\n"
-"PO-Revision-Date: 2020-10-21T15:10:29.336Z\n"
+"POT-Creation-Date: 2020-09-12T01:09:55.979Z\n"
+"PO-Revision-Date: 2020-09-12T01:09:55.979Z\n"
 
 msgid "Failed to get data from Data Store"
 msgstr ""
@@ -85,6 +85,21 @@ msgstr ""
 msgid "Set defaults and save"
 msgstr ""
 
+msgid "Select Manual option"
+msgstr ""
+
+msgid ""
+"By selecting Manual there will NOT be any AUTOMATIC SYNCHRONIZATION of "
+"data. Your users will need to sync manually for data to be sent to the "
+"server."
+msgstr ""
+
+msgid "Do you want to select this option?"
+msgstr ""
+
+msgid "Yes"
+msgstr ""
+
 msgid "Save in DataStore"
 msgstr ""
 
@@ -157,6 +172,14 @@ msgstr ""
 msgid "These settings apply to all Android users."
 msgstr ""
 
+msgid "Manual options"
+msgstr ""
+
+msgid ""
+"Manual options for data and metadata sync are only available from android "
+"app version 2.3.0 onwards."
+msgstr ""
+
 msgid "Summary Settings"
 msgstr ""
 
@@ -193,6 +216,9 @@ msgstr ""
 msgid ""
 "You have unsaved changes, if you leave you will lose your changes. Are you "
 "sure you want to leave?"
+msgstr ""
+
+msgid "Manual"
 msgstr ""
 
 msgid "1 Day"

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-09-12T01:09:55.979Z\n"
-"PO-Revision-Date: 2020-09-12T01:09:55.979Z\n"
+"POT-Creation-Date: 2020-10-30T17:09:59.408Z\n"
+"PO-Revision-Date: 2020-10-30T17:09:59.408Z\n"
 
 msgid "Failed to get data from Data Store"
 msgstr ""
@@ -112,7 +112,7 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-msgid "Values per"
+msgid "Values per {{title}}"
 msgstr ""
 
 msgid "Add/Save"
@@ -198,12 +198,6 @@ msgstr ""
 msgid "Default"
 msgstr ""
 
-msgid "Download"
-msgstr ""
-
-msgid "Actions"
-msgstr ""
-
 msgid "Edit"
 msgstr ""
 
@@ -218,13 +212,13 @@ msgid ""
 "sure you want to leave?"
 msgstr ""
 
-msgid "Manual"
-msgstr ""
-
 msgid "1 Day"
 msgstr ""
 
 msgid "1 Week"
+msgstr ""
+
+msgid "Manual"
 msgstr ""
 
 msgid "30 Minutes"

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-08-22T02:50:32.289Z\n"
-"PO-Revision-Date: 2020-08-22T02:50:32.289Z\n"
+"POT-Creation-Date: 2020-10-08T23:47:41.991Z\n"
+"PO-Revision-Date: 2020-10-08T23:47:41.991Z\n"
 
 msgid "Failed to get data from Data Store"
 msgstr ""
@@ -165,6 +165,9 @@ msgstr ""
 msgid "Summary Settings"
 msgstr ""
 
+msgid "Recommended maximum: {{maxValue}}"
+msgstr ""
+
 msgid "User sync test"
 msgstr ""
 
@@ -302,10 +305,16 @@ msgstr ""
 msgid "Number of program rules to download"
 msgstr ""
 
-msgid "metadata download size"
+msgid "reserved values per TEI"
 msgstr ""
 
-msgid "data download size"
+msgid "Number of reserved values downloaded per TEI attribute"
+msgstr ""
+
+msgid "metadata download size (KB)"
+msgstr ""
+
+msgid "data download size (KB)"
 msgstr ""
 
 msgid "{{teiDownload}} TEI"

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@dhis2/app-runtime": "^2.0.4",
     "@dhis2/d2-ui-core": "^6.3.0",
     "@dhis2/d2-ui-table": "^6.3.0",
+    "@dhis2/ui": "^5.5.0",
     "@material-ui/core": "^3.9.2",
     "d2": "^31.7",
     "d3-color": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "android-settings-app",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": "Milagros Rodriguez <sharmynrodriguez@gmail.com>",
   "private": true,
   "dependencies": {

--- a/src/App.js
+++ b/src/App.js
@@ -3,13 +3,14 @@ import React from 'react'
 import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles'
 
 import { App as D2UIApp, mui3theme as dhis2theme } from '@dhis2/d2-ui-core'
-
+import { CssVariables } from '@dhis2/ui'
 import './App.css'
 import Layout from './pages/layout'
 
 const App = () => {
     return (
         <div className="app__container">
+            <CssVariables colors spacers />
             <D2UIApp>
                 <MuiThemeProvider theme={createMuiTheme(dhis2theme)}>
                     <Layout />

--- a/src/components/dialog-table.js
+++ b/src/components/dialog-table.js
@@ -1,18 +1,19 @@
 import React from 'react'
 
-import Dialog from '@material-ui/core/Dialog'
-import DialogActions from '@material-ui/core/DialogActions'
-import DialogContent from '@material-ui/core/DialogContent'
-import DialogTitle from '@material-ui/core/DialogTitle'
-import Select from '@material-ui/core/Select'
-import MenuItem from '@material-ui/core/MenuItem'
-import { Button, ButtonStrip } from '@dhis2/ui-core'
-
+import {
+    Modal,
+    ModalTitle,
+    ModalContent,
+    ModalActions,
+    Button,
+    ButtonStrip,
+} from '@dhis2/ui'
 import ProgramTable from './settings-table/program-table'
 import DataSetTable from './settings-table/dataset-table'
 import i18n from '@dhis2/d2-i18n'
 import titleStyles from '../styles/LayoutTitles.module.css'
 import buttonStyles from '../styles/Button.module.css'
+import { Select } from './inputs'
 
 const DialogTable = ({
     open,
@@ -26,80 +27,66 @@ const DialogTable = ({
     handleSubmitDialog,
     specificSetting,
     completeListOptions,
-}) => {
-    return (
-        <Dialog
-            open={open}
-            onClose={handleClose}
-            aria-labelledby="form-dialog-title"
-            fullWidth
-            maxWidth="lg"
-        >
-            <DialogTitle id="form-dialog-title">
-                {i18n.t('Values per')} {title}
-            </DialogTitle>
-            <DialogContent>
-                {dataTitle === undefined ? (
-                    <Select
-                        value={titleValue}
-                        onChange={handleChange}
-                        id="name"
-                        name="name"
-                        style={{ minWidth: '150px' }}
-                    >
-                        {dataTitleOptions.map(option => (
-                            <MenuItem
-                                value={option.id}
-                                key={option.id}
-                                name={option.name}
-                            >
-                                <em> {option.name} </em>
-                            </MenuItem>
-                        ))}
-                    </Select>
-                ) : (
-                    <p className={titleStyles.mainContent__title__dialog}>
-                        {dataTitle}
-                    </p>
-                )}
+}) => (
+    <>
+        {open && (
+            <Modal large onClose={handleClose} position="middle">
+                <ModalTitle>
+                    {i18n.t('Values per {{title}}', { title })}
+                </ModalTitle>
+                <ModalContent>
+                    {dataTitle === undefined ? (
+                        <Select
+                            name="name"
+                            inputWidth="300px"
+                            onChange={handleChange}
+                            value={titleValue}
+                            options={dataTitleOptions}
+                        />
+                    ) : (
+                        <p className={titleStyles.mainContent__title__dialog}>
+                            {dataTitle}
+                        </p>
+                    )}
 
-                {title === 'Programs' ? (
-                    <ProgramTable
-                        data={data}
-                        states={specificSetting}
-                        onChange={handleChange}
-                        programTitle={dataTitle}
-                        programOptions={dataTitleOptions}
-                        programSelected={titleValue}
-                        completeListOptions={completeListOptions}
-                    />
-                ) : (
-                    <DataSetTable
-                        data={data}
-                        states={specificSetting}
-                        onChange={handleChange}
-                        dataSetTitle={dataTitle}
-                        dataSetOptions={dataTitleOptions}
-                        dataSetSelected={titleValue}
-                        completeListOptions={completeListOptions}
-                    />
-                )}
-            </DialogContent>
-            <DialogActions>
-                <ButtonStrip end>
-                    <Button
-                        onClick={handleClose}
-                        className={buttonStyles.mainContent__dialog__button}
-                    >
-                        {i18n.t('Cancel')}
-                    </Button>
-                    <Button onClick={handleSubmitDialog}>
-                        {i18n.t('Add/Save')}
-                    </Button>
-                </ButtonStrip>
-            </DialogActions>
-        </Dialog>
-    )
-}
+                    {title === 'Programs' ? (
+                        <ProgramTable
+                            data={data}
+                            states={specificSetting}
+                            onChange={handleChange}
+                            programTitle={dataTitle}
+                            programOptions={dataTitleOptions}
+                            programSelected={titleValue}
+                            completeListOptions={completeListOptions}
+                        />
+                    ) : (
+                        <DataSetTable
+                            data={data}
+                            states={specificSetting}
+                            onChange={handleChange}
+                            dataSetTitle={dataTitle}
+                            dataSetOptions={dataTitleOptions}
+                            dataSetSelected={titleValue}
+                            completeListOptions={completeListOptions}
+                        />
+                    )}
+                </ModalContent>
+                <ModalActions>
+                    <ButtonStrip end>
+                        <Button
+                            onClick={handleClose}
+                            className={buttonStyles.mainContent__dialog__button}
+                        >
+                            {i18n.t('Cancel')}
+                        </Button>
+                        <Button onClick={handleSubmitDialog}>
+                            {i18n.t('Add/Save')}
+                        </Button>
+                    </ButtonStrip>
+                </ModalActions>
+            </Modal>
+        )}
+    </>
+)
 
 export default DialogTable

--- a/src/components/dialog/dialog-manual-alert.js
+++ b/src/components/dialog/dialog-manual-alert.js
@@ -1,0 +1,47 @@
+import React from 'react'
+
+import {
+    Modal,
+    ModalTitle,
+    ModalContent,
+    ModalActions,
+    ButtonStrip,
+    Button,
+} from '@dhis2/ui'
+import i18n from '@dhis2/d2-i18n'
+import PropTypes from '@dhis2/prop-types'
+
+const DialogManualAlert = ({ openDialog, onClose, chooseOption }) => (
+    <>
+        {openDialog && (
+            <Modal small onClose={onClose} position="middle">
+                <ModalTitle>{i18n.t('Select Manual option')}</ModalTitle>
+                <ModalContent>
+                    <p>
+                        {i18n.t(
+                            'By selecting Manual there will NOT be any AUTOMATIC SYNCHRONIZATION of data. Your users will need to sync manually for data to be sent to the server.'
+                        )}
+                    </p>
+
+                    <p>{i18n.t('Do you want to select this option?')}</p>
+                </ModalContent>
+                <ModalActions>
+                    <ButtonStrip end>
+                        <Button onClick={onClose}>{i18n.t('Cancel')}</Button>
+                        <Button onClick={chooseOption} primary>
+                            {i18n.t('Yes')}
+                        </Button>
+                    </ButtonStrip>
+                </ModalActions>
+            </Modal>
+        )}
+    </>
+)
+
+DialogManualAlert.propTypes = {
+    openDialog: PropTypes.bool.isRequired,
+    onClose: PropTypes.func.isRequired,
+    chooseOption: PropTypes.func.isRequired,
+}
+
+export default DialogManualAlert

--- a/src/components/dialog/dialog-manual-alert.js
+++ b/src/components/dialog/dialog-manual-alert.js
@@ -10,38 +10,52 @@ import {
 } from '@dhis2/ui'
 import i18n from '@dhis2/d2-i18n'
 import PropTypes from '@dhis2/prop-types'
+import { DATA, METADATA, METADATA_SYNC } from '../../constants/android-settings'
 
-const DialogManualAlert = ({ openDialog, onClose, chooseOption }) => (
-    <>
-        {openDialog && (
-            <Modal small onClose={onClose} position="middle">
-                <ModalTitle>{i18n.t('Select Manual option')}</ModalTitle>
-                <ModalContent>
-                    <p>
-                        {i18n.t(
-                            'By selecting Manual there will NOT be any AUTOMATIC SYNCHRONIZATION of data. Your users will need to sync manually for data to be sent to the server.'
-                        )}
-                    </p>
+const DialogManualAlert = ({
+    openDialog,
+    onClose,
+    chooseOption,
+    manualOptionType,
+}) => {
+    const type = manualOptionType === METADATA_SYNC ? METADATA : DATA
 
-                    <p>{i18n.t('Do you want to select this option?')}</p>
-                </ModalContent>
-                <ModalActions>
-                    <ButtonStrip end>
-                        <Button onClick={onClose}>{i18n.t('Cancel')}</Button>
-                        <Button onClick={chooseOption} primary>
-                            {i18n.t('Yes')}
-                        </Button>
-                    </ButtonStrip>
-                </ModalActions>
-            </Modal>
-        )}
-    </>
-)
+    return (
+        <>
+            {openDialog && (
+                <Modal small onClose={onClose} position="middle">
+                    <ModalTitle>{i18n.t('Select Manual option')}</ModalTitle>
+                    <ModalContent>
+                        <p>
+                            {i18n.t(
+                                'By selecting Manual there will NOT be any AUTOMATIC SYNCHRONIZATION of {{type}}. Your users will need to download the {{type}} manually.',
+                                { type }
+                            )}
+                        </p>
+
+                        <p>{i18n.t('Do you want to select this option?')}</p>
+                    </ModalContent>
+                    <ModalActions>
+                        <ButtonStrip end>
+                            <Button onClick={onClose}>
+                                {i18n.t('Cancel')}
+                            </Button>
+                            <Button onClick={chooseOption} primary>
+                                {i18n.t('Yes')}
+                            </Button>
+                        </ButtonStrip>
+                    </ModalActions>
+                </Modal>
+            )}
+        </>
+    )
+}
 
 DialogManualAlert.propTypes = {
     openDialog: PropTypes.bool.isRequired,
     onClose: PropTypes.func.isRequired,
     chooseOption: PropTypes.func.isRequired,
+    manualOptionType: PropTypes.string,
 }
 
 export default DialogManualAlert

--- a/src/components/footer-action-buttons.js
+++ b/src/components/footer-action-buttons.js
@@ -1,0 +1,35 @@
+import React from 'react'
+import i18n from '@dhis2/d2-i18n'
+import PropTypes from '@dhis2/prop-types'
+import buttonStyles from '../styles/Button.module.css'
+import { Button, ButtonStrip } from '@dhis2/ui'
+
+const FooterActionButtons = ({
+    saveButtonDisabled,
+    resetButtonDisabled,
+    onResetClick,
+    onSave,
+}) => (
+    <ButtonStrip className={buttonStyles.container__padding}>
+        <Button
+            primary
+            className={buttonStyles.button_marginLeft}
+            onClick={onSave}
+            disabled={saveButtonDisabled}
+        >
+            {i18n.t('Save')}
+        </Button>
+        <Button onClick={onResetClick} disabled={resetButtonDisabled}>
+            {i18n.t('Reset all values to default')}
+        </Button>
+    </ButtonStrip>
+)
+
+FooterActionButtons.propTypes = {
+    saveButtonDisabled: PropTypes.bool,
+    resetButtonDisabled: PropTypes.bool,
+    onResetClick: PropTypes.func,
+    onSave: PropTypes.func,
+}
+
+export default FooterActionButtons

--- a/src/components/inputs/index.js
+++ b/src/components/inputs/index.js
@@ -1,0 +1,4 @@
+export * from './input-number'
+export * from './radio-field'
+export * from './select'
+export * from './select-settings'

--- a/src/components/inputs/input-number.js
+++ b/src/components/inputs/input-number.js
@@ -1,0 +1,29 @@
+import React from 'react'
+import { InputField } from '@dhis2/ui'
+import PropTypes from '@dhis2/prop-types'
+
+export const InputNumber = ({
+    onChange,
+    keyDownload,
+    maxValue,
+    value,
+    disabled,
+}) => (
+    <InputField
+        type="number"
+        inputWidth="100px"
+        name={keyDownload}
+        max={maxValue}
+        value={value.toString()}
+        onChange={onChange}
+        disabled={disabled}
+    />
+)
+
+InputNumber.propTypes = {
+    keyDownload: PropTypes.string,
+    maxValue: PropTypes.number,
+    value: PropTypes.number,
+    onChange: PropTypes.func,
+    disabled: PropTypes.bool,
+}

--- a/src/components/inputs/radio-field.js
+++ b/src/components/inputs/radio-field.js
@@ -1,0 +1,36 @@
+import React from 'react'
+import { RadioGroup, Radio } from '@dhis2/ui-core'
+import PropTypes from '@dhis2/prop-types'
+
+export const RadioField = ({
+    onChange,
+    keyDownload,
+    value,
+    disabled,
+    options,
+}) => (
+    <RadioGroup
+        dense
+        name={keyDownload}
+        id={keyDownload}
+        onChange={onChange}
+        value={value}
+        disabled={disabled}
+    >
+        {options.map(option => (
+            <Radio
+                key={option.value}
+                label={option.label}
+                value={option.value}
+            />
+        ))}
+    </RadioGroup>
+)
+
+RadioField.propTypes = {
+    keyDownload: PropTypes.string,
+    onChange: PropTypes.func,
+    value: PropTypes.string,
+    disabled: PropTypes.bool,
+    options: PropTypes.array,
+}

--- a/src/components/inputs/select-settings.js
+++ b/src/components/inputs/select-settings.js
@@ -1,0 +1,32 @@
+import React from 'react'
+import { Select } from './select'
+import PropTypes from '@dhis2/prop-types'
+
+export const SelectSettings = ({
+    onChange,
+    label,
+    keyDownload,
+    value,
+    disabled,
+    options,
+}) => (
+    <Select
+        key={keyDownload}
+        inputWidth="200px"
+        label={label}
+        name={keyDownload}
+        value={value}
+        disabled={disabled}
+        onChange={onChange}
+        options={options}
+    />
+)
+
+SelectSettings.propTypes = {
+    keyDownload: PropTypes.string,
+    onChange: PropTypes.func,
+    label: PropTypes.string,
+    value: PropTypes.string,
+    disabled: PropTypes.bool,
+    options: PropTypes.array,
+}

--- a/src/components/inputs/select.js
+++ b/src/components/inputs/select.js
@@ -1,0 +1,42 @@
+import React from 'react'
+import { SingleSelectField, SingleSelectOption } from '@dhis2/ui'
+import PropTypes from '@dhis2/prop-types'
+
+export const Select = ({
+    onChange,
+    label,
+    name,
+    value,
+    disabled,
+    options,
+    inputWidth,
+}) => (
+    <SingleSelectField
+        inputWidth={inputWidth}
+        key={name}
+        label={label}
+        selected={value}
+        id={name}
+        name={name}
+        onChange={e => onChange(e, name)}
+        disabled={disabled}
+    >
+        {options.map(option => (
+            <SingleSelectOption
+                key={option.value || option.id}
+                label={option.label || option.name}
+                value={option.value || option.id}
+            />
+        ))}
+    </SingleSelectField>
+)
+
+Select.propTypes = {
+    onChange: PropTypes.func,
+    label: PropTypes.string,
+    name: PropTypes.string,
+    value: PropTypes.string,
+    disabled: PropTypes.bool,
+    options: PropTypes.array,
+    inputWidth: PropTypes.string,
+}

--- a/src/components/notice-alert.js
+++ b/src/components/notice-alert.js
@@ -1,0 +1,19 @@
+import React from 'react'
+import { NoticeBox } from '@dhis2/ui'
+
+const NoticeAlert = ({ title, notice }) => (
+    <div>
+        <NoticeBox title={title} warning>
+            {notice}
+        </NoticeBox>
+        <style jsx>
+            {`
+                 {
+                    margin-bottom: 20px;
+                }
+            `}
+        </style>
+    </div>
+)
+
+export default NoticeAlert

--- a/src/components/sections/general/android-settings-container.js
+++ b/src/components/sections/general/android-settings-container.js
@@ -1,13 +1,12 @@
 import React, { useEffect, useState } from 'react'
 
-import { CircularLoader } from '@dhis2/ui-core'
 import GeneralSettings from './general-settings'
-import UnsavedChangesAlert from '../../unsaved-changes-alert'
 import { apiLoadGeneralSettings } from '../../../modules/general/apiLoadSettings'
 import { useNavigation } from '../../../utils/useNavigation'
 import { useGeneralForm } from '../../../modules/general/useGeneralForm'
 import { useSaveGeneralSettings } from '../../../modules/general/useSaveGeneralSettings'
 import { removeNamespace } from '../../../modules/general/removeNamespace'
+import SectionWrapper from '../section-wrapper'
 
 const AndroidSettingsContainer = () => {
     const [submitDataStore, setSubmitDataStore] = useState({
@@ -81,14 +80,8 @@ const AndroidSettingsContainer = () => {
         },
     }
 
-    if (loading === true) {
-        return <CircularLoader small />
-    }
-
     return (
-        <>
-            <UnsavedChangesAlert unsavedChanges={!form.disableSave} />
-
+        <SectionWrapper loading={loading} unsavedChanges={!form.disableSave}>
             <GeneralSettings
                 state={{
                     openDialog,
@@ -99,7 +92,7 @@ const AndroidSettingsContainer = () => {
                 handleSaveDialog={handleSaveDataDialog}
                 handleDisableSettings={handleDisableSettings}
             />
-        </>
+        </SectionWrapper>
     )
 }
 

--- a/src/components/sections/general/form-sections/button-field.js
+++ b/src/components/sections/general/form-sections/button-field.js
@@ -1,0 +1,21 @@
+import React from 'react'
+import PropTypes from '@dhis2/prop-types'
+import formStyles from '../../../../styles/Form.module.css'
+import { Button, Field } from '@dhis2/ui'
+
+export const ButtonField = ({ label, helpText, onOpen, disabled }) => (
+    <div className={formStyles.rowMargin}>
+        <Field helpText={helpText}>
+            <Button onClick={onOpen} disabled={disabled}>
+                {label}
+            </Button>
+        </Field>
+    </div>
+)
+
+ButtonField.propTypes = {
+    label: PropTypes.string,
+    helpText: PropTypes.string,
+    onOpen: PropTypes.func,
+    disabled: PropTypes.bool,
+}

--- a/src/components/sections/general/form-sections/form-section.js
+++ b/src/components/sections/general/form-sections/form-section.js
@@ -1,0 +1,11 @@
+import React from 'react'
+import PropTypes from '@dhis2/prop-types'
+import formStyles from '../../../../styles/Form.module.css'
+
+export const FormSection = props => (
+    <div className={formStyles.row}>{props.children}</div>
+)
+
+FormSection.propTypes = {
+    children: PropTypes.element,
+}

--- a/src/components/sections/general/form-sections/index.js
+++ b/src/components/sections/general/form-sections/index.js
@@ -1,0 +1,6 @@
+export * from './form-section'
+export * from './button-field'
+export * from './sync-checkbox-field'
+export * from './sync-input-number-field'
+export * from './sync-input-phone-field'
+export * from './sync-select-field'

--- a/src/components/sections/general/form-sections/sync-checkbox-field.js
+++ b/src/components/sections/general/form-sections/sync-checkbox-field.js
@@ -1,0 +1,34 @@
+import React from 'react'
+import PropTypes from '@dhis2/prop-types'
+import { CheckboxField } from '@dhis2/ui'
+import { FormSection } from './form-section'
+
+export const SyncCheckboxField = ({
+    label,
+    helpText,
+    name,
+    checked,
+    disabled,
+    onChange,
+}) => (
+    <FormSection>
+        <CheckboxField
+            label={label}
+            helpText={helpText}
+            name={name}
+            checked={checked}
+            disabled={disabled}
+            type="checkbox"
+            onChange={onChange}
+        />
+    </FormSection>
+)
+
+SyncCheckboxField.propTypes = {
+    label: PropTypes.string,
+    helpText: PropTypes.string,
+    name: PropTypes.string,
+    checked: PropTypes.bool,
+    disabled: PropTypes.bool,
+    onChange: PropTypes.func,
+}

--- a/src/components/sections/general/form-sections/sync-input-number-field.js
+++ b/src/components/sections/general/form-sections/sync-input-number-field.js
@@ -1,0 +1,25 @@
+import React from 'react'
+import PropTypes from '@dhis2/prop-types'
+import { InputField } from '@dhis2/ui'
+import { FormSection } from './form-section'
+
+export const SyncInputNumberField = ({ syncElement, handleForm }) => {
+    const { label, syncType } = syncElement
+    return (
+        <FormSection>
+            <InputField
+                inputWidth="100px"
+                label={label}
+                {...handleForm.getInputNumber(syncType)}
+            />
+        </FormSection>
+    )
+}
+
+SyncInputNumberField.propTypes = {
+    syncElement: PropTypes.shape({
+        label: PropTypes.string,
+        syncType: PropTypes.string,
+    }),
+    handleForm: PropTypes.object,
+}

--- a/src/components/sections/general/form-sections/sync-input-phone-field.js
+++ b/src/components/sections/general/form-sections/sync-input-phone-field.js
@@ -1,0 +1,28 @@
+import React from 'react'
+import PropTypes from '@dhis2/prop-types'
+import { InputField } from '@dhis2/ui'
+import { FormSection } from './form-section'
+
+export const SyncInputPhoneField = ({ handleForm, syncElement }) => {
+    const { label, helpText, syncType } = syncElement
+    return (
+        <FormSection>
+            <InputField
+                type="tel"
+                inputWidth="250px"
+                helpText={helpText}
+                label={label}
+                {...handleForm.getPhoneNumber(syncType)}
+            />
+        </FormSection>
+    )
+}
+
+SyncInputPhoneField.propTypes = {
+    syncElement: PropTypes.shape({
+        label: PropTypes.string,
+        helpText: PropTypes.string,
+        syncType: PropTypes.string,
+    }),
+    handleForm: PropTypes.object,
+}

--- a/src/components/sections/general/form-sections/sync-select-field.js
+++ b/src/components/sections/general/form-sections/sync-select-field.js
@@ -1,0 +1,37 @@
+import React from 'react'
+import PropTypes from '@dhis2/prop-types'
+import { SingleSelectField, SingleSelectOption } from '@dhis2/ui'
+import { FormSection } from './form-section'
+
+export const SyncSelectField = ({ syncElement, handleForm }) => {
+    const { label, options, syncType } = syncElement
+    return (
+        <FormSection>
+            <SingleSelectField
+                inputWidth="250px"
+                label={label}
+                onChange={payload =>
+                    handleForm.onChangeSelect(payload, syncType)
+                }
+                {...handleForm.getSelect(syncType)}
+            >
+                {options.map(option => (
+                    <SingleSelectOption
+                        key={option.value}
+                        label={option.label}
+                        value={option.value}
+                    />
+                ))}
+            </SingleSelectField>
+        </FormSection>
+    )
+}
+
+SyncSelectField.propTypes = {
+    syncElement: PropTypes.shape({
+        label: PropTypes.string,
+        syncType: PropTypes.string,
+        options: PropTypes.array,
+    }),
+    handleForm: PropTypes.object,
+}

--- a/src/components/sections/general/general-form.js
+++ b/src/components/sections/general/general-form.js
@@ -1,173 +1,74 @@
 import React from 'react'
-
-import TextField from '@material-ui/core/TextField'
-import {
-    dataOptions,
-    maxValues,
-    metadataOptions,
-} from '../../../constants/android-settings'
-import { Button, ButtonStrip, CheckboxField, Help } from '@dhis2/ui-core'
-import MenuItem from '@material-ui/core/MenuItem'
-import i18n from '@dhis2/d2-i18n'
 import PropTypes from '@dhis2/prop-types'
-
-import styles from '../../../styles/LayoutTitles.module.css'
-import buttonStyles from '../../../styles/Button.module.css'
+import { generalSettingsFormSections } from '../../../constants/android-settings'
+import {
+    SyncSelectField,
+    SyncInputPhoneField,
+    SyncInputNumberField,
+    SyncCheckboxField,
+    ButtonField,
+} from './form-sections'
+import FooterActionButtons from '../../footer-action-buttons'
 
 const GeneralForm = ({
     handleSaveDialog,
     handleForm,
     handleDisableSettings,
-}) => {
-    return (
-        <form>
-            <TextField
-                label={i18n.t('How often should metadata sync?')}
-                margin="normal"
-                select
-                fullWidth
-                InputLabelProps={{
-                    shrink: true,
-                }}
-                {...handleForm.getSelect('metadataSync')}
-            >
-                {metadataOptions.map(option => (
-                    <MenuItem key={option.value} value={option.value}>
-                        {option.label}
-                    </MenuItem>
-                ))}
-            </TextField>
+}) => (
+    <form>
+        <SyncSelectField
+            syncElement={generalSettingsFormSections.metadata}
+            handleForm={handleForm}
+        />
 
-            <TextField
-                label={i18n.t('How often should data sync?')}
-                margin="normal"
-                select
-                fullWidth
-                InputLabelProps={{
-                    shrink: true,
-                }}
-                {...handleForm.getSelect('dataSync')}
-            >
-                {dataOptions.map(option => (
-                    <MenuItem key={option.value} value={option.value}>
-                        {option.label}
-                    </MenuItem>
-                ))}
-            </TextField>
+        <SyncSelectField
+            syncElement={generalSettingsFormSections.data}
+            handleForm={handleForm}
+        />
 
-            <TextField
-                type="tel"
-                InputProps={{
-                    inputProps: {
-                        minLength: '4',
-                        pattern: '^\\+[1-9][0-9]{3,16}$',
-                    },
-                }}
-                label={i18n.t('SMS Gateway phone number')}
-                helperText={
-                    handleForm.errorNumber.numberSmsToSend
-                        ? i18n.t(
-                              'This phone number is not valid. Must start with + and be at least 4 characters long.'
-                          )
-                        : i18n.t(
-                              'Must start with + and be at least 4 characters long.'
-                          )
-                }
-                margin="normal"
-                fullWidth
-                InputLabelProps={{
-                    shrink: true,
-                }}
-                {...handleForm.getPhoneNumber('numberSmsToSend')}
-            />
+        <SyncInputPhoneField
+            syncElement={generalSettingsFormSections.smsToSend}
+            handleForm={handleForm}
+        />
 
-            <TextField
-                type="tel"
-                InputProps={{
-                    inputProps: {
-                        minLength: '4',
-                        pattern: '^\\+[1-9][0-9]{3,16}$',
-                    },
-                }}
-                label={i18n.t('SMS Result Sender phone number')}
-                helperText={
-                    handleForm.errorNumber.numberSmsConfirmation
-                        ? i18n.t(
-                              'This phone number is not valid. Must start with + and be at least 4 characters long.'
-                          )
-                        : i18n.t(
-                              'Must start with + and be at least 4 characters long.'
-                          )
-                }
-                margin="normal"
-                fullWidth
-                InputLabelProps={{
-                    shrink: true,
-                }}
-                {...handleForm.getPhoneNumber('numberSmsConfirmation')}
-            />
+        <SyncInputPhoneField
+            syncElement={generalSettingsFormSections.smsConfirmation}
+            handleForm={handleForm}
+        />
 
-            <TextField
-                label={i18n.t('Reserved values downloaded per TEI attribute')}
-                type="number"
-                margin="normal"
-                fullWidth
-                InputLabelProps={{
-                    shrink: true,
-                }}
-                InputProps={{
-                    inputProps: {
-                        min: 0,
-                        step: 10,
-                        max: maxValues.reservedValues,
-                    },
-                }}
-                {...handleForm.getInput('reservedValues')}
-            />
+        <SyncInputNumberField
+            syncElement={generalSettingsFormSections.reservedValues}
+            handleForm={handleForm}
+        />
 
-            <div className={styles.field__form__container}>
-                <CheckboxField
-                    label={i18n.t('Encrypt device database')}
-                    helpText={i18n.t(
-                        'Encrypt all data stored on device. Data can be lost if there are problems with an encrypted database. This will not affect the DHIS2 database stored on an external server.'
-                    )}
-                    {...handleForm.getCheckbox('encryptDB')}
-                />
-            </div>
+        <SyncCheckboxField
+            label={generalSettingsFormSections.encryptDB.label}
+            helpText={generalSettingsFormSections.encryptDB.helpText}
+            name={generalSettingsFormSections.encryptDB.syncType}
+            checked={
+                handleForm.fields[
+                    generalSettingsFormSections.encryptDB.syncType
+                ]
+            }
+            disabled={handleForm.fields.disableAll}
+            onChange={handleForm.handleEncryptDialog.onChange}
+        />
 
-            <div>
-                <Button
-                    onClick={handleDisableSettings.open}
-                    disabled={handleForm.fields.disableAll}
-                >
-                    {i18n.t('Disable all settings')}
-                </Button>
-                <Help>
-                    {i18n.t(
-                        'This will disable and remove all General, Program and Data set settings.'
-                    )}
-                </Help>
-            </div>
+        <ButtonField
+            label={generalSettingsFormSections.disableSettings.label}
+            helpText={generalSettingsFormSections.disableSettings.helpText}
+            onOpen={handleDisableSettings.open}
+            disabled={handleForm.fields.disableAll}
+        />
 
-            <ButtonStrip className={buttonStyles.container__padding}>
-                <Button
-                    primary
-                    className={buttonStyles.button_marginLeft}
-                    onClick={handleSaveDialog.open}
-                    disabled={handleForm.disableSave}
-                >
-                    {i18n.t('Save')}
-                </Button>
-                <Button
-                    onClick={handleForm.handleReset}
-                    disabled={handleForm.fields.disableAll}
-                >
-                    {i18n.t('Reset all values to default')}
-                </Button>
-            </ButtonStrip>
-        </form>
-    )
-}
+        <FooterActionButtons
+            saveButtonDisabled={handleForm.disableSave}
+            resetButtonDisabled={handleForm.fields.disableAll}
+            onResetClick={handleForm.handleReset}
+            onSave={handleSaveDialog.open}
+        />
+    </form>
+)
 
 GeneralForm.propTypes = {
     handleForm: PropTypes.object.isRequired,

--- a/src/components/sections/general/general-settings.js
+++ b/src/components/sections/general/general-settings.js
@@ -17,62 +17,54 @@ const GeneralSettings = ({
     generalForm,
     handleSaveDialog,
     handleDisableSettings,
-}) => {
-    return (
-        <>
-            <div>
-                <p className={styles.mainContent__title_headerBar}>
-                    {i18n.t('General download sync settings')}
-                </p>
-                <p className={styles.mainContent__subtitle}>
-                    {i18n.t('These settings apply to all Android users.')}
-                </p>
-            </div>
+}) => (
+    <>
+        <div>
+            <p className={styles.mainContent__title_headerBar}>
+                {i18n.t('General download sync settings')}
+            </p>
+            <p className={styles.mainContent__subtitle}>
+                {i18n.t('These settings apply to all Android users.')}
+            </p>
+        </div>
 
-            <GeneralForm
-                handleForm={generalForm}
-                handleSaveDialog={handleSaveDialog}
-                handleDisableSettings={handleDisableSettings}
-            />
+        <GeneralForm
+            handleForm={generalForm}
+            handleSaveDialog={handleSaveDialog}
+            handleDisableSettings={handleDisableSettings}
+        />
 
-            <DialogEncrypt
-                openDialog={generalForm.openEncryptDialog}
-                checked={generalForm.fields.encryptDB}
-                onClose={generalForm.handleEncryptDialog.onClose}
-                handleEncrypt={generalForm.handleEncryptDialog.handleEncrypt}
-            />
+        <DialogEncrypt
+            openDialog={generalForm.openEncryptDialog}
+            checked={generalForm.fields.encryptDB}
+            onClose={generalForm.handleEncryptDialog.onClose}
+            handleEncrypt={generalForm.handleEncryptDialog.handleEncrypt}
+        />
 
-            <DialogSaveData
-                openDialog={state.openDialog.saveData}
-                onClose={handleSaveDialog.close}
-                saveDataStore={handleSaveDialog.save}
-            />
+        <DialogSaveData
+            openDialog={state.openDialog.saveData}
+            onClose={handleSaveDialog.close}
+            saveDataStore={handleSaveDialog.save}
+        />
 
-            <DialogDisableSettings
-                openDialog={state.openDialog.disableSettings}
-                onClose={handleDisableSettings.cancel}
-                disableSettings={handleDisableSettings.disableSettings}
-            />
+        <DialogDisableSettings
+            openDialog={state.openDialog.disableSettings}
+            onClose={handleDisableSettings.cancel}
+            disableSettings={handleDisableSettings.disableSettings}
+        />
 
-            <SuccessAlert
-                show={
-                    state.submitDataStore.success &&
-                    !state.submitDataStore.error
-                }
-            />
+        <SuccessAlert
+            show={state.submitDataStore.success && !state.submitDataStore.error}
+        />
 
-            <SaveErrorAlert
-                show={
-                    state.submitDataStore.error &&
-                    !state.submitDataStore.success
-                }
-                message={state.submitDataStore.message}
-            />
+        <SaveErrorAlert
+            show={state.submitDataStore.error && !state.submitDataStore.success}
+            message={state.submitDataStore.message}
+        />
 
-            <ErrorAlert show={state.openErrorAlert} />
-        </>
-    )
-}
+        <ErrorAlert show={state.openErrorAlert} />
+    </>
+)
 
 GeneralSettings.propTypes = {
     state: PropTypes.object.isRequired,

--- a/src/components/sections/general/general-settings.js
+++ b/src/components/sections/general/general-settings.js
@@ -47,6 +47,7 @@ const GeneralSettings = ({
             openDialog={generalForm.manualAlertDialog.open}
             chooseOption={generalForm.handleManualAlert.save}
             onClose={generalForm.handleManualAlert.close}
+            manualOptionType={generalForm.manualAlertDialog.selection.name}
         />
 
         <DialogEncrypt

--- a/src/components/sections/general/general-settings.js
+++ b/src/components/sections/general/general-settings.js
@@ -11,6 +11,8 @@ import GeneralForm from './general-form'
 
 import styles from '../../../styles/LayoutTitles.module.css'
 import DialogDisableSettings from '../../dialog/dialog-disable-settings'
+import NoticeAlert from '../../notice-alert'
+import DialogManualAlert from '../../dialog/dialog-manual-alert'
 
 const GeneralSettings = ({
     state,
@@ -28,10 +30,23 @@ const GeneralSettings = ({
             </p>
         </div>
 
+        <NoticeAlert
+            title={i18n.t('Manual options')}
+            notice={i18n.t(
+                'Manual options for data and metadata sync are only available from android app version 2.3.0 onwards.'
+            )}
+        />
+
         <GeneralForm
             handleForm={generalForm}
             handleSaveDialog={handleSaveDialog}
             handleDisableSettings={handleDisableSettings}
+        />
+
+        <DialogManualAlert
+            openDialog={generalForm.manualAlertDialog.open}
+            chooseOption={generalForm.handleManualAlert.save}
+            onClose={generalForm.handleManualAlert.close}
         />
 
         <DialogEncrypt

--- a/src/components/sections/section-wrapper.js
+++ b/src/components/sections/section-wrapper.js
@@ -1,0 +1,25 @@
+import React from 'react'
+import { CircularLoader } from '@dhis2/ui'
+import PropTypes from '@dhis2/prop-types'
+import UnsavedChangesAlert from '../unsaved-changes-alert'
+
+const SectionWrapper = ({ loading, unsavedChanges, children }) => {
+    if (loading === true) {
+        return <CircularLoader small />
+    }
+
+    return (
+        <>
+            <UnsavedChangesAlert unsavedChanges={unsavedChanges} />
+            {children}
+        </>
+    )
+}
+
+SectionWrapper.propTypes = {
+    loading: PropTypes.bool,
+    unsavedChanges: PropTypes.bool,
+    children: PropTypes.element.isRequired,
+}
+
+export default SectionWrapper

--- a/src/components/sections/user-sync-test/run-test.js
+++ b/src/components/sections/user-sync-test/run-test.js
@@ -8,6 +8,7 @@ import Divider from '@material-ui/core/Divider'
 import Grid from '@material-ui/core/Grid'
 import { CircularLoader } from '@dhis2/ui-core'
 import i18n from '@dhis2/d2-i18n'
+import cx from 'classnames'
 
 const RunTest = ({ states }) => {
     return (
@@ -21,14 +22,14 @@ const RunTest = ({ states }) => {
                                     <CircularLoader small />
                                 ) : (
                                     <p
-                                        className={`${
-                                            itemStyles.subItemBigItem
-                                        } ${
-                                            states[test.state] >=
-                                            states[test.maxValueState]
-                                                ? itemStyles.maxValue
-                                                : ''
-                                        }`}
+                                        className={cx(
+                                            itemStyles.subItemBigItem,
+                                            {
+                                                [itemStyles.maxValue]:
+                                                    states[test.state] >=
+                                                    states[test.maxValueState],
+                                            }
+                                        )}
                                     >
                                         {states[test.state]}
                                     </p>
@@ -44,8 +45,13 @@ const RunTest = ({ states }) => {
                                         {test.title}
                                     </p>
                                     <p className={itemStyles.subItemItem}>
-                                        {i18n.t('Recommended maximum:')}{' '}
-                                        {test.maxValue}
+                                        {i18n.t(
+                                            'Recommended maximum: {{maxValue}}',
+                                            {
+                                                nsSeparator: '---',
+                                                maxValue: test.maxValue,
+                                            }
+                                        )}
                                     </p>
                                 </div>
                             </Grid>

--- a/src/components/sections/user-sync-test/user-sync-test-container.js
+++ b/src/components/sections/user-sync-test/user-sync-test-container.js
@@ -4,7 +4,11 @@ import { CircularLoader } from '@dhis2/ui-core'
 
 import TestAndroid from './test-android'
 import { formatByteSize, memorySizeOf } from '../../../utils/memory-size'
-import { NAMESPACE, PROGRAM_SETTINGS } from '../../../constants/data-store'
+import {
+    GENERAL_SETTINGS,
+    NAMESPACE,
+    PROGRAM_SETTINGS,
+} from '../../../constants/data-store'
 
 import api from '../../../utils/api'
 import { getDownloadSize } from '../../../modules/userSyncTest/downloadSize'
@@ -30,6 +34,7 @@ class UserSyncTestContainer extends React.Component {
         this.globalSettings = undefined
         this.specificSettings = undefined
         this.organisationUnitsCapture = undefined
+        this.reservedValues = 0
     }
 
     state = {
@@ -59,6 +64,9 @@ class UserSyncTestContainer extends React.Component {
         programRuleLoad: false,
         metadataLoad: false,
         dataLoad: false,
+        reservedValueNumber: 0,
+        maxValueReservedValue: 0,
+        reservedValuesLoad: false,
     }
 
     updateRecommendedValue = () => {
@@ -88,6 +96,7 @@ class UserSyncTestContainer extends React.Component {
             programRuleNumber: 0,
             metadataSize: 0,
             dataSize: 0,
+            reservedValueNumber: 0,
             loadData: false,
             orgUnitLoad: false,
             dataSetLoad: false,
@@ -95,6 +104,7 @@ class UserSyncTestContainer extends React.Component {
             programRuleLoad: false,
             metadataLoad: false,
             dataLoad: false,
+            reservedValuesLoad: false,
         })
     }
 
@@ -189,6 +199,7 @@ class UserSyncTestContainer extends React.Component {
                 programRuleLoad: false,
                 metadataLoad: false,
                 dataLoad: false,
+                reservedValuesLoad: true,
             })
 
             await Promise.all(promisesOrganisationUnits).then(data => {
@@ -421,6 +432,8 @@ class UserSyncTestContainer extends React.Component {
                                 programRuleNumber: programRuleResult.toArray()
                                     .length,
                                 metadataSize: metadata,
+                                reservedValueNumber: this.reservedValues,
+                                reservedValuesLoad: false,
                             })
                         }
                     )
@@ -506,10 +519,14 @@ class UserSyncTestContainer extends React.Component {
                 })
             })
 
-        api.getValue(NAMESPACE, PROGRAM_SETTINGS)
+        Promise.all([
+            api.getValue(NAMESPACE, PROGRAM_SETTINGS),
+            api.getValue(NAMESPACE, GENERAL_SETTINGS),
+        ])
             .then(res => {
-                this.globalSettings = res.value.globalSettings
-                this.specificSettings = res.value.specificSettings
+                this.globalSettings = res[0].value.globalSettings
+                this.specificSettings = res[0].value.specificSettings
+                this.reservedValues = res[1].value.reservedValues
             })
             .catch(e => {
                 console.error(e)

--- a/src/components/settings-table/dataset-table-row.js
+++ b/src/components/settings-table/dataset-table-row.js
@@ -1,11 +1,10 @@
 import React from 'react'
 
-import TableRow from '@material-ui/core/TableRow'
-import TableCell from '@material-ui/core/TableCell'
-import InputNumber from '../input-number'
 import i18n from '@dhis2/d2-i18n'
-import dataTableStyles from '../../styles/DataTable.module.css'
 import tableTitleStyles from '../../styles/TableTitle.module.css'
+import { InputNumber } from '../inputs'
+import TableRow from './table-row'
+import { Divider } from '@dhis2/ui'
 
 const DataSetTableRow = ({
     dataRow,
@@ -13,34 +12,28 @@ const DataSetTableRow = ({
     defaultValue,
     states,
     onChange,
-}) => {
-    return (
+}) => (
+    <div>
         <TableRow>
-            <TableCell
-                component="th"
-                scope="row"
-                className={dataTableStyles.dataTable__rows__row__column}
-            >
+            <div>
                 <p>
                     {dataRow.option} ({periodType})
                 </p>
                 <em className={tableTitleStyles.attributeLabel}>
                     {i18n.t('Default')} : {defaultValue}
                 </em>
-            </TableCell>
-            <TableCell
-                className={dataTableStyles.dataTable__rows__row__column}
-                align="right"
-            >
+            </div>
+            <div>
                 <InputNumber
-                    name={dataRow.keyDownload}
-                    max={dataRow.maxValue}
-                    value={states[dataRow.keyDownload]}
                     onChange={onChange}
+                    keyDownload={dataRow.keyDownload}
+                    value={states[dataRow.keyDownload]}
+                    disabled={states.disableAll}
                 />
-            </TableCell>
+            </div>
         </TableRow>
-    )
-}
+        <Divider />
+    </div>
+)
 
 export default DataSetTableRow

--- a/src/components/settings-table/dataset-table.js
+++ b/src/components/settings-table/dataset-table.js
@@ -1,126 +1,59 @@
-import React from 'react'
-
-import Table from '@material-ui/core/Table'
-import TableBody from '@material-ui/core/TableBody'
-import TableCell from '@material-ui/core/TableCell'
-import TableHead from '@material-ui/core/TableHead'
-import TableRow from '@material-ui/core/TableRow'
+import React, { useEffect, useState } from 'react'
+import Wrapper from '../wrapper'
 import DataSetTableRow from './dataset-table-row'
-
-import i18n from '@dhis2/d2-i18n'
-import dataTableStyles from '../../styles/DataTable.module.css'
 import { periodTypeConstants } from '../../constants/data-set-settings'
 
-class DataSetTable extends React.Component {
-    constructor(props) {
-        super(props)
+const DataSetTable = props => {
+    const [dataSet, setDataset] = useState(props.dataSetSelected)
+    const [dataSetData, setData] = useState(props.data)
+    const [periodType, setPeriodType] = useState('')
+    const [defaultValue, setDefault] = useState('')
+    const [dataSetFilter, setDataSetFiltered] = useState('')
+    const [selected, setSelected] = useState(false)
 
-        this.state = {
-            dataSetSelected: this.props.dataSetSelected,
-            dataSetFilter: '',
-            periodType: '',
-            defaultValue: '',
-            selected: false,
-        }
-    }
-
-    checkPeriodType = () => {
-        if (this.props.dataSetSelected !== '') {
-            const dataSetSelected = this.props.completeListOptions.filter(
-                dataSet => dataSet.id === this.props.dataSetSelected
+    const checkPeriodType = () => {
+        if (props.dataSetSelected !== '') {
+            const dataSetSelected = props.completeListOptions.filter(
+                dataSetOption => dataSetOption.id === props.dataSetSelected
             )
-            this.dataSetFilter = dataSetSelected[0]
 
-            this.props.states.periodDSDownload =
+            setDataset(props.dataSetSelected)
+            setDataSetFiltered(dataSetSelected)
+            setPeriodType(dataSetSelected[0].periodType)
+            setDefault(
                 periodTypeConstants[dataSetSelected[0].periodType].default
-
-            this.setState({
-                dataSetSelected: this.props.dataSetSelected,
-                dataSetFilter: dataSetSelected,
-                periodType: this.dataSetFilter.periodType,
-                defaultValue:
-                    periodTypeConstants[dataSetSelected[0].periodType].default,
-                selected: true,
-            })
-        }
-    }
-
-    checkPeriodTypeEdit = () => {
-        if (this.props.dataSetSelected !== '') {
-            const dataSetSelected = this.props.completeListOptions.filter(
-                dataSet => dataSet.id === this.props.dataSetSelected
             )
-            this.dataSetFilter = dataSetSelected[0]
-
-            this.setState({
-                dataSetSelected: this.props.dataSetSelected,
-                dataSetFilter: dataSetSelected,
-                periodType: this.dataSetFilter.periodType,
-                defaultValue:
-                    periodTypeConstants[dataSetSelected[0].periodType].default,
-                selected: true,
-            })
+            setSelected(true)
         }
     }
 
-    componentDidUpdate() {
-        if (this.props.dataSetSelected !== '') {
-            if (!this.state.dataSetSelected) {
-                this.checkPeriodType()
-            } else if (
-                this.state.dataSetSelected !== this.props.dataSetSelected
-            ) {
-                this.checkPeriodType()
-            } else if (!this.state.periodType) {
-                this.checkPeriodTypeEdit()
+    useEffect(() => {
+        if (props.dataSetSelected !== '') {
+            if (!dataSet || !periodType || dataSet !== props.dataSetSelected) {
+                checkPeriodType()
             }
         }
-    }
+    })
 
-    render() {
-        if (this.props.dataSetSelected === '') {
-            return null
-        }
-
-        if (this.state.dataSetSelected || this.state.periodType) {
-            return (
-                <Table className={dataTableStyles.dataTable}>
-                    <TableHead>
-                        <TableRow>
-                            <TableCell
-                                className={
-                                    dataTableStyles.dataTable__headers__header
-                                }
-                            >
-                                {' '}
-                            </TableCell>
-                            <TableCell
-                                className={
-                                    dataTableStyles.dataTable__headers__header
-                                }
-                                align="right"
-                            >
-                                {i18n.t('Download')}
-                            </TableCell>
-                        </TableRow>
-                    </TableHead>
-                    <TableBody>
-                        {this.props.data.map(row => (
-                            <DataSetTableRow
-                                key={row.option}
-                                dataRow={row}
-                                periodType={this.state.periodType}
-                                defaultValue={this.state.defaultValue}
-                                states={this.props.states}
-                                onChange={this.props.onChange}
-                            />
-                        ))}
-                    </TableBody>
-                </Table>
-            )
-        }
-
+    if (!dataSet || !periodType || props.dataSetSelected === '') {
         return null
+    } else {
+        return (
+            <Wrapper fullWidth>
+                <div>
+                    {dataSetData.map(row => (
+                        <DataSetTableRow
+                            key={row.option}
+                            dataRow={row}
+                            periodType={periodType}
+                            defaultValue={defaultValue}
+                            states={props.states}
+                            onChange={props.onChange}
+                        />
+                    ))}
+                </div>
+            </Wrapper>
+        )
     }
 }
 

--- a/src/components/settings-table/program-global-settings.js
+++ b/src/components/settings-table/program-global-settings.js
@@ -1,43 +1,24 @@
 import React from 'react'
 import SettingsTable from './settings-table'
-import { MenuItem, TextField } from '@material-ui/core'
+import { SelectSettings } from '../inputs'
 import { GlobalSettingLevel } from '../../constants/program-settings'
-
 import inputStyles from '../../styles/Input.module.css'
 
-const ProgramGlobalSettings = ({ states, data, handleChange }) => {
-    return (
-        <React.Fragment>
-            <div className={inputStyles.container__initial}>
-                <TextField
-                    id={GlobalSettingLevel.keyDownload}
-                    name={GlobalSettingLevel.keyDownload}
-                    label={GlobalSettingLevel.option}
-                    margin="normal"
-                    select
-                    InputLabelProps={{
-                        shrink: true,
-                    }}
-                    value={states[GlobalSettingLevel.keyDownload]}
-                    onChange={handleChange}
-                    className={inputStyles.container_minWidth}
-                    disabled={states.disableAll}
-                >
-                    {GlobalSettingLevel.download.map(option => (
-                        <MenuItem key={option.value} value={option.value}>
-                            {option.label}
-                        </MenuItem>
-                    ))}
-                </TextField>
-            </div>
-
-            <SettingsTable
-                data={data}
-                states={states}
+const ProgramGlobalSettings = ({ states, data, handleChange }) => (
+    <React.Fragment>
+        <div className={inputStyles.container__initial}>
+            <SelectSettings
                 onChange={handleChange}
+                keyDownload={GlobalSettingLevel.keyDownload}
+                value={states[GlobalSettingLevel.keyDownload]}
+                disabled={states.disableAll}
+                options={GlobalSettingLevel.download}
+                label={GlobalSettingLevel.option}
             />
-        </React.Fragment>
-    )
-}
+        </div>
+
+        <SettingsTable data={data} states={states} onChange={handleChange} />
+    </React.Fragment>
+)
 
 export default ProgramGlobalSettings

--- a/src/components/settings-table/program-table-row.js
+++ b/src/components/settings-table/program-table-row.js
@@ -1,26 +1,18 @@
 import React from 'react'
-
-import Select from '@material-ui/core/Select'
-import MenuItem from '@material-ui/core/MenuItem'
-import TableRow from '@material-ui/core/TableRow'
-import TableCell from '@material-ui/core/TableCell'
-import InputNumber from '../input-number'
 import i18n from '@dhis2/d2-i18n'
-import dataTableStyles from '../../styles/DataTable.module.css'
 import tableTitleStyles from '../../styles/TableTitle.module.css'
 import {
     specificSettingsDefault,
     TEI_DOWNLOAD,
 } from '../../constants/program-settings'
+import { InputNumber, SelectSettings } from '../inputs'
+import TableRow from './table-row'
+import { Divider } from '@dhis2/ui'
 
-const ProgramTableRow = ({ dataRow, states, onChange }) => {
-    return (
+const ProgramTableRow = ({ dataRow, states, onChange }) => (
+    <div>
         <TableRow>
-            <TableCell
-                component="th"
-                scope="row"
-                className={dataTableStyles.dataTable__rows__row__column}
-            >
+            <div>
                 <p> {dataRow.option} </p>
                 {dataRow.maxValue ? (
                     <em className={tableTitleStyles.attributeLabel}>
@@ -32,40 +24,30 @@ const ProgramTableRow = ({ dataRow, states, onChange }) => {
                 ) : (
                     false
                 )}
-            </TableCell>
-            <TableCell
-                className={`${dataTableStyles.dataTable__rows__row__column} ${dataTableStyles.dataTable_align_end}`}
-                align="right"
-            >
+            </div>
+            <div>
                 {Array.isArray(dataRow.download) === true ? (
-                    <Select
+                    <SelectSettings
                         key={dataRow.keyDownload}
-                        value={states[dataRow.keyDownload]}
                         onChange={onChange}
-                        id={dataRow.keyDownload}
-                        name={dataRow.keyDownload}
-                    >
-                        {dataRow.download.map(option => (
-                            <MenuItem
-                                value={option.value}
-                                key={option.value}
-                                name={option.value}
-                            >
-                                <em> {option.label} </em>
-                            </MenuItem>
-                        ))}
-                    </Select>
+                        keyDownload={dataRow.keyDownload}
+                        value={states[dataRow.keyDownload]}
+                        disabled={states.disableAll}
+                        options={dataRow.download}
+                    />
                 ) : (
                     <InputNumber
-                        name={dataRow.keyDownload}
-                        max={dataRow.maxValue}
-                        value={states[dataRow.keyDownload]}
                         onChange={onChange}
+                        keyDownload={dataRow.keyDownload}
+                        maxValue={dataRow.maxValue}
+                        value={states[dataRow.keyDownload]}
+                        disabled={states.disableAll}
                     />
                 )}
-            </TableCell>
+            </div>
         </TableRow>
-    )
-}
+        <Divider />
+    </div>
+)
 
 export default ProgramTableRow

--- a/src/components/settings-table/program-table.js
+++ b/src/components/settings-table/program-table.js
@@ -1,106 +1,59 @@
-import React from 'react'
-
-import Table from '@material-ui/core/Table'
-import TableBody from '@material-ui/core/TableBody'
-import TableCell from '@material-ui/core/TableCell'
-import TableHead from '@material-ui/core/TableHead'
-import TableRow from '@material-ui/core/TableRow'
+import React, { useEffect, useState } from 'react'
 import { WITH_REGISTRATION } from '../../constants/program-settings'
-
-import i18n from '@dhis2/d2-i18n'
-import dataTableStyles from '../../styles/DataTable.module.css'
 import ProgramTableRow from './program-table-row'
+import Wrapper from '../wrapper'
 
-class ProgramTable extends React.Component {
-    constructor(props) {
-        super(props)
-        this.programTable = props
+const ProgramTable = props => {
+    const [program, setProgram] = useState(props.programSelected)
+    const [programData, setData] = useState(props.data)
+    const [programFilter, setProgramFiltered] = useState('')
+    const [programType, setProgramType] = useState('')
 
-        this.state = {
-            programSelected: this.props.programSelected,
-            programFilter: '',
-            programType: '',
-        }
-    }
-
-    checkProgramType = () => {
-        if (this.props.programSelected !== '') {
-            const programSelected = this.props.completeListOptions.filter(
-                program => program.id === this.props.programSelected
+    const checkProgramType = () => {
+        if (props.programSelected !== '') {
+            const programSelected = props.completeListOptions.filter(
+                programOption => programOption.id === props.programSelected
             )
-            this.programFilter = programSelected[0]
-            this.setState({
-                programSelected: this.props.programSelected,
-                programFilter: programSelected,
-                programType: this.programFilter.programType,
-            })
+            setProgram(props.programSelected)
+            setProgramFiltered(programSelected)
+            setProgramType(programSelected[0].programType)
         }
     }
 
-    componentDidUpdate() {
-        if (this.props.programSelected !== '') {
-            if (!this.state.programSelected) {
-                this.checkProgramType()
-            } else if (
-                this.state.programSelected !== this.props.programSelected
-            ) {
-                this.checkProgramType()
-            } else if (!this.state.programType) {
-                this.checkProgramType()
+    useEffect(() => {
+        if (props.programSelected !== '') {
+            if (!program || !programType || program !== props.programSelected) {
+                checkProgramType()
             }
         }
-    }
+    })
 
-    render() {
-        if (this.props.programSelected === '') {
-            return null
-        }
-
-        if (this.state.programSelected || this.state.programType) {
-            return (
-                <Table className={dataTableStyles.dataTable}>
-                    <TableHead>
-                        <TableRow>
-                            <TableCell
-                                className={
-                                    dataTableStyles.dataTable__headers__header
-                                }
-                            >
-                                {' '}
-                            </TableCell>
-                            <TableCell
-                                className={
-                                    dataTableStyles.dataTable__headers__header
-                                }
-                                align="right"
-                            >
-                                {i18n.t('Download')}
-                            </TableCell>
-                        </TableRow>
-                    </TableHead>
-                    <TableBody className="data-table__rows">
-                        {this.state.programType === WITH_REGISTRATION
-                            ? this.props.data.withRegistration.map(row => (
-                                  <ProgramTableRow
-                                      key={row.option}
-                                      dataRow={row}
-                                      states={this.props.states}
-                                      onChange={this.props.onChange}
-                                  />
-                              ))
-                            : this.props.data.withoutRegistration.map(row => (
-                                  <ProgramTableRow
-                                      key={row.option}
-                                      dataRow={row}
-                                      states={this.props.states}
-                                      onChange={this.props.onChange}
-                                  />
-                              ))}
-                    </TableBody>
-                </Table>
-            )
-        }
+    if (!program || !programType || props.programSelected === '') {
         return null
+    } else {
+        return (
+            <Wrapper fullWidth>
+                <div>
+                    {programType === WITH_REGISTRATION
+                        ? programData.withRegistration.map(row => (
+                              <ProgramTableRow
+                                  key={row.option}
+                                  dataRow={row}
+                                  states={props.states}
+                                  onChange={props.onChange}
+                              />
+                          ))
+                        : programData.withoutRegistration.map(row => (
+                              <ProgramTableRow
+                                  key={row.option}
+                                  dataRow={row}
+                                  states={props.states}
+                                  onChange={props.onChange}
+                              />
+                          ))}
+                </div>
+            </Wrapper>
+        )
     }
 }
 

--- a/src/components/settings-table/setting-table-row.js
+++ b/src/components/settings-table/setting-table-row.js
@@ -1,80 +1,58 @@
 import React from 'react'
-
-import Select from '@material-ui/core/Select'
-import MenuItem from '@material-ui/core/MenuItem'
-import { TableRow, TableCell, RadioGroup, Radio } from '@dhis2/ui-core'
-import InputNumber from '../input-number'
+import { Divider } from '@dhis2/ui'
 import cx from 'classnames'
-import dataTableStyles from '../../styles/DataTable.module.css'
-import radioStyles from '../../styles/Input.module.css'
 import disable from '../../styles/Disable.module.css'
+import { InputNumber, RadioField, SelectSettings } from '../inputs'
+import TableRow from './table-row'
 
-const SettingsTableRow = ({ dataRow, states, onChange }) => {
-    return (
+const InputChoice = ({ dataRow, states, onChange }) => (
+    <>
+        {Array.isArray(dataRow.download) === true ? (
+            dataRow.radioButton === true ? (
+                <RadioField
+                    onChange={onChange}
+                    keyDownload={dataRow.keyDownload}
+                    value={states[dataRow.keyDownload]}
+                    disabled={states.disableAll}
+                    options={dataRow.download}
+                />
+            ) : (
+                <SelectSettings
+                    onChange={onChange}
+                    keyDownload={dataRow.keyDownload}
+                    value={states[dataRow.keyDownload]}
+                    disabled={states.disableAll}
+                    options={dataRow.download}
+                />
+            )
+        ) : (
+            <InputNumber
+                onChange={onChange}
+                keyDownload={dataRow.keyDownload}
+                maxValue={dataRow.maxValue}
+                value={states[dataRow.keyDownload]}
+                disabled={states.disableAll}
+            />
+        )}
+    </>
+)
+
+const SettingsTableRow = ({ dataRow, states, onChange }) => (
+    <div>
         <TableRow>
-            <TableCell
-                className={cx({ [disable.disable_label]: states.disableAll })}
-            >
+            <div className={cx({ [disable.disable_label]: states.disableAll })}>
                 {dataRow.option}
-            </TableCell>
-            <TableCell
-                className={cx(
-                    dataTableStyles.dataTable__rows__row__column,
-                    dataTableStyles.dataTable_align_end
-                )}
-                align="right"
-            >
-                {Array.isArray(dataRow.download) === true ? (
-                    dataRow.radioButton === true ? (
-                        <RadioGroup
-                            dense
-                            name={dataRow.keyDownload}
-                            id={dataRow.keyDownload}
-                            onChange={onChange}
-                            value={states[dataRow.keyDownload]}
-                            className={radioStyles.container_content_inline}
-                            disabled={states.disableAll}
-                        >
-                            {dataRow.download.map(option => (
-                                <Radio
-                                    key={option.value}
-                                    label={option.label}
-                                    value={option.value}
-                                />
-                            ))}
-                        </RadioGroup>
-                    ) : (
-                        <Select
-                            key={dataRow.keyDownload}
-                            value={states[dataRow.keyDownload]}
-                            onChange={onChange}
-                            id={dataRow.keyDownload}
-                            name={dataRow.keyDownload}
-                            disabled={states.disableAll}
-                        >
-                            {dataRow.download.map(option => (
-                                <MenuItem
-                                    value={option.value}
-                                    key={option.value}
-                                    name={option.value}
-                                >
-                                    <em> {option.label} </em>
-                                </MenuItem>
-                            ))}
-                        </Select>
-                    )
-                ) : (
-                    <InputNumber
-                        name={dataRow.keyDownload}
-                        max={dataRow.maxValue}
-                        value={states[dataRow.keyDownload]}
-                        onChange={onChange}
-                        disabled={states.disableAll}
-                    />
-                )}
-            </TableCell>
+            </div>
+            <div>
+                <InputChoice
+                    dataRow={dataRow}
+                    states={states}
+                    onChange={onChange}
+                />
+            </div>
         </TableRow>
-    )
-}
+        <Divider />
+    </div>
+)
 
 export default SettingsTableRow

--- a/src/components/settings-table/settings-table.js
+++ b/src/components/settings-table/settings-table.js
@@ -1,24 +1,20 @@
 import React from 'react'
-
-import { Table, TableBody } from '@dhis2/ui-core'
 import SettingsTableRow from './setting-table-row'
-import dataTableStyles from '../../styles/DataTable.module.css'
+import Wrapper from '../wrapper'
 
-const SettingsTable = ({ data, states, onChange }) => {
-    return (
-        <Table className={dataTableStyles.dataTable}>
-            <TableBody className="data-table__rows">
-                {data.map(row => (
-                    <SettingsTableRow
-                        key={row.option}
-                        dataRow={row}
-                        states={states}
-                        onChange={onChange}
-                    />
-                ))}
-            </TableBody>
-        </Table>
-    )
-}
+const SettingsTable = ({ data, states, onChange }) => (
+    <Wrapper>
+        <div>
+            {data.map(row => (
+                <SettingsTableRow
+                    key={row.option}
+                    dataRow={row}
+                    states={states}
+                    onChange={onChange}
+                />
+            ))}
+        </div>
+    </Wrapper>
+)
 
 export default SettingsTable

--- a/src/components/settings-table/table-row.js
+++ b/src/components/settings-table/table-row.js
@@ -1,0 +1,6 @@
+import React from 'react'
+import styles from '../../styles/TableSettings.module.css'
+
+const TableRow = props => <div className={styles.parent}>{props.children}</div>
+
+export default TableRow

--- a/src/components/table-actions.js
+++ b/src/components/table-actions.js
@@ -1,81 +1,78 @@
 import React from 'react'
 
-import {
-    Table,
-    TableHead,
-    TableRowHead,
-    TableCellHead,
-    TableBody,
-    TableRow,
-    TableCell,
-    ButtonStrip,
-    Button,
-} from '@dhis2/ui-core'
+import { ButtonStrip, Button, Card } from '@dhis2/ui'
 import i18n from '@dhis2/d2-i18n'
 import PropTypes from '@dhis2/prop-types'
 import cx from 'classnames'
 import dataTableStyles from '../styles/DataTable.module.css'
 import disableStyle from '../styles/Disable.module.css'
+import tableActionStyles from '../styles/TableActions.module.css'
+import Wrapper from './wrapper'
 
-const TableActions = ({ columns, rows, menuActions, states }) => {
-    return (
-        <Table>
-            <TableHead>
-                <TableRowHead>
-                    {columns.map(column => (
-                        <TableCellHead key={column}>{column}</TableCellHead>
-                    ))}
-                    <TableCellHead>{i18n.t('Actions')}</TableCellHead>
-                </TableRowHead>
-            </TableHead>
-            <TableBody>
-                {rows.map(row => (
-                    <TableRow key={row.id}>
-                        <TableCell
-                            className={cx(dataTableStyles.dataTable_row_title, {
+const TableActions = ({ rows, menuActions, states }) => (
+    <Wrapper>
+        <div>
+            <TableRows rows={rows} menuActions={menuActions} states={states} />
+        </div>
+    </Wrapper>
+)
+
+const TableRows = ({ rows, states, menuActions }) => (
+    <div>
+        {rows.map(row => (
+            <Card key={row.id} className={tableActionStyles.wrapper}>
+                <div className={tableActionStyles.parent}>
+                    <div>
+                        <div
+                            className={cx(tableActionStyles.title, {
                                 [disableStyle.disable_label]: states.disableAll,
                             })}
                         >
                             {row.name}
-                        </TableCell>
-                        <TableCell
-                            className={cx(dataTableStyles.dataTable_row_title, {
-                                [disableStyle.disable_label]: states.disableAll,
-                            })}
+                        </div>
+                        <div
+                            className={cx(
+                                tableActionStyles.subtitle,
+                                dataTableStyles.dataTable_row_title,
+                                {
+                                    [disableStyle.disable_label]:
+                                        states.disableAll,
+                                }
+                            )}
                         >
                             {row.summarySettings}
-                        </TableCell>
+                        </div>
+                    </div>
 
-                        <TableCell dense>
-                            <ButtonStrip>
-                                <Button
-                                    small
-                                    secondary
-                                    onClick={() => {
-                                        menuActions.edit(row)
-                                    }}
-                                    disabled={states.disableAll}
-                                >
-                                    {i18n.t('Edit')}
-                                </Button>
-                                <Button
-                                    small
-                                    secondary
-                                    onClick={() => {
-                                        menuActions.delete(row)
-                                    }}
-                                    disabled={states.disableAll}
-                                >
-                                    {i18n.t('Delete')}
-                                </Button>
-                            </ButtonStrip>
-                        </TableCell>
-                    </TableRow>
-                ))}
-            </TableBody>
-        </Table>
-    )
-}
+                    <div>
+                        <ButtonStrip>
+                            <Button
+                                small
+                                secondary
+                                onClick={() => {
+                                    menuActions.edit(row)
+                                }}
+                                disabled={states.disableAll}
+                            >
+                                {i18n.t('Edit')}
+                            </Button>
+                            <Button
+                                small
+                                secondary
+                                onClick={() => {
+                                    menuActions.delete(row)
+                                }}
+                                disabled={states.disableAll}
+                            >
+                                {i18n.t('Delete')}
+                            </Button>
+                        </ButtonStrip>
+                    </div>
+                </div>
+            </Card>
+        ))}
+    </div>
+)
 
 TableActions.propTypes = {
     columns: PropTypes.array.isRequired,

--- a/src/components/wrapper.js
+++ b/src/components/wrapper.js
@@ -1,0 +1,21 @@
+import React from 'react'
+import cx from 'classnames'
+import PropTypes from '@dhis2/prop-types'
+import styles from '../styles/TableActions.module.css'
+
+const Wrapper = ({ children, fullWidth }) => (
+    <div
+        className={cx(styles.container, {
+            [styles.fullContainer]: fullWidth,
+        })}
+    >
+        {children}
+    </div>
+)
+
+Wrapper.propTypes = {
+    children: PropTypes.element.isRequired,
+    fullWidth: PropTypes.bool,
+}
+
+export default Wrapper

--- a/src/constants/android-settings.js
+++ b/src/constants/android-settings.js
@@ -3,34 +3,34 @@ import i18n from '@dhis2/d2-i18n'
 export const metadataOptions = [
     {
         value: '24h',
-        label: '24h',
+        label: '1 Day',
     },
     {
         value: '7d',
-        label: '7d',
+        label: '1 Week',
     },
 ]
 
 export const dataOptions = [
     {
         value: '30m',
-        label: '30m',
+        label: '30 Minutes',
     },
     {
         value: '1h',
-        label: '1h',
+        label: '1 Hour',
     },
     {
         value: '6h',
-        label: '6h',
+        label: '6 Hours',
     },
     {
         value: '12h',
-        label: '12h',
+        label: '12 Hours',
     },
     {
         value: '24h',
-        label: '24h',
+        label: '1 Day',
     },
 ]
 

--- a/src/constants/android-settings.js
+++ b/src/constants/android-settings.js
@@ -1,5 +1,10 @@
 import i18n from '@dhis2/d2-i18n'
 
+export const RESERVED_VALUES = 'reservedValues'
+export const MANUAL = 'manual'
+export const SMS_TO_SEND = 'numberSmsToSend'
+export const SMS_CONFIRMATION = 'numberSmsConfirmation'
+
 export const metadataOptions = [
     {
         value: '24h',
@@ -8,6 +13,10 @@ export const metadataOptions = [
     {
         value: '7d',
         label: i18n.t('1 Week'),
+    },
+    {
+        value: MANUAL,
+        label: i18n.t('Manual'),
     },
 ]
 
@@ -32,6 +41,10 @@ export const dataOptions = [
         value: '24h',
         label: i18n.t('1 Day'),
     },
+    {
+        value: MANUAL,
+        label: i18n.t('Manual'),
+    },
 ]
 
 export const maxValues = {
@@ -49,10 +62,6 @@ export const androidSettingsDefault = {
     reservedValues: 100,
     encryptDB: false,
 }
-
-export const RESERVED_VALUES = 'reservedValues'
-export const SMS_TO_SEND = 'numberSmsToSend'
-export const SMS_CONFIRMATION = 'numberSmsConfirmation'
 
 export const generalSettingsFormSections = {
     metadata: {

--- a/src/constants/android-settings.js
+++ b/src/constants/android-settings.js
@@ -4,6 +4,9 @@ export const RESERVED_VALUES = 'reservedValues'
 export const MANUAL = 'manual'
 export const SMS_TO_SEND = 'numberSmsToSend'
 export const SMS_CONFIRMATION = 'numberSmsConfirmation'
+export const METADATA_SYNC = 'metadataSync'
+export const METADATA = 'metadata'
+export const DATA = 'data'
 
 export const metadataOptions = [
     {

--- a/src/constants/android-settings.js
+++ b/src/constants/android-settings.js
@@ -3,34 +3,34 @@ import i18n from '@dhis2/d2-i18n'
 export const metadataOptions = [
     {
         value: '24h',
-        label: '1 Day',
+        label: i18n.t('1 Day'),
     },
     {
         value: '7d',
-        label: '1 Week',
+        label: i18n.t('1 Week'),
     },
 ]
 
 export const dataOptions = [
     {
         value: '30m',
-        label: '30 Minutes',
+        label: i18n.t('30 Minutes'),
     },
     {
         value: '1h',
-        label: '1 Hour',
+        label: i18n.t('1 Hour'),
     },
     {
         value: '6h',
-        label: '6 Hours',
+        label: i18n.t('6 Hours'),
     },
     {
         value: '12h',
-        label: '12 Hours',
+        label: i18n.t('12 Hours'),
     },
     {
         value: '24h',
-        label: '1 Day',
+        label: i18n.t('1 Day'),
     },
 ]
 
@@ -51,3 +51,65 @@ export const androidSettingsDefault = {
 }
 
 export const RESERVED_VALUES = 'reservedValues'
+export const SMS_TO_SEND = 'numberSmsToSend'
+export const SMS_CONFIRMATION = 'numberSmsConfirmation'
+
+export const generalSettingsFormSections = {
+    metadata: {
+        syncType: 'metadataSync',
+        label: i18n.t('How often should metadata sync?'),
+        options: metadataOptions,
+        helpText: '',
+    },
+    data: {
+        syncType: 'dataSync',
+        label: i18n.t('How often should data sync?'),
+        options: dataOptions,
+        helpText: '',
+    },
+    smsToSend: {
+        syncType: 'numberSmsToSend',
+        label: i18n.t('SMS Gateway phone number'),
+        options: '',
+        helpText: i18n.t(
+            'Must start with + and be at least 4 characters long.'
+        ),
+        validationText: i18n.t(
+            'This phone number is not valid. Must start with + and be at least 4 characters long.'
+        ),
+    },
+    smsConfirmation: {
+        syncType: 'numberSmsConfirmation',
+        label: i18n.t('SMS Result Sender phone number'),
+        options: '',
+        helpText: i18n.t(
+            'Must start with + and be at least 4 characters long.'
+        ),
+        validationText: i18n.t(
+            'This phone number is not valid. Must start with + and be at least 4 characters long.'
+        ),
+    },
+    reservedValues: {
+        syncType: 'reservedValues',
+        label: i18n.t('Reserved values downloaded per TEI attribute'),
+        options: '',
+        helpText: '',
+        maxValues: maxValues.reservedValues,
+    },
+    encryptDB: {
+        syncType: 'encryptDB',
+        label: i18n.t('Encrypt device database'),
+        options: '',
+        helpText: i18n.t(
+            'Encrypt all data stored on device. Data can be lost if there are problems with an encrypted database. This will not affect the DHIS2 database stored on an external server.'
+        ),
+    },
+    disableSettings: {
+        syncType: 'disableSettings',
+        label: i18n.t('Disable all settings'),
+        options: '',
+        helpText: i18n.t(
+            'This will disable and remove all General, Program and Data set settings.'
+        ),
+    },
+}

--- a/src/constants/data-set-settings.js
+++ b/src/constants/data-set-settings.js
@@ -107,6 +107,7 @@ export const SPECIFIC = 'SPECIFIC'
 export const GLOBAL = 'GLOBAL'
 export const DEFAULT = 'DEFAULT'
 export const CLEAN = 'CLEAN'
+export const SPECIFIC_SETTINGS = 'SPECIFIC_SETTINGS'
 
 export const PERIOD_DS_DOWNLOAD = 'periodDSDownload'
 export const PERIOD_DS_DB_TRIMMING = 'periodDSDBTrimming'

--- a/src/constants/test-android.js
+++ b/src/constants/test-android.js
@@ -51,7 +51,18 @@ export const testAndroidDataConstants = [
         maxValue: 50,
     },
     {
-        title: i18n.t('metadata download size'),
+        title: i18n.t('reserved values per TEI'),
+        description: i18n.t(
+            'Number of reserved values downloaded per TEI attribute'
+        ),
+        tooltipTitle: 'tooltipReservedValue',
+        state: 'reservedValueNumber',
+        maxValueState: 'maxValueReservedValue',
+        load: 'reservedValuesLoad',
+        maxValue: 500,
+    },
+    {
+        title: i18n.t('metadata download size (KB)'),
         description: '',
         tooltipTitle: 'tooltipMetadata',
         state: 'metadataSize',
@@ -60,7 +71,7 @@ export const testAndroidDataConstants = [
         maxValue: 1000,
     },
     {
-        title: i18n.t('data download size'),
+        title: i18n.t('data download size (KB)'),
         description: '',
         tooltipTitle: 'tooltipData',
         state: 'dataSize',

--- a/src/modules/dataset/parseValueBySettingType.js
+++ b/src/modules/dataset/parseValueBySettingType.js
@@ -7,7 +7,7 @@ export const parseValueBySettingType = (name, value) => {
     switch (name) {
         case PERIOD_DS_DOWNLOAD:
         case PERIOD_DS_DB_TRIMMING:
-            return value ? parseInt(value) : 0
+            return isNaN(parseInt(value)) ? 0 : Math.max(0, parseInt(value))
         default:
             return value
     }

--- a/src/modules/dataset/populateSettingObject.js
+++ b/src/modules/dataset/populateSettingObject.js
@@ -3,7 +3,9 @@ import {
     dataSetSettingsDefault,
     DEFAULT,
     GLOBAL,
+    periodTypeConstants,
     SPECIFIC,
+    SPECIFIC_SETTINGS,
 } from '../../constants/data-set-settings'
 const { periodDSDownload } = dataSetSettingsDefault
 
@@ -28,6 +30,12 @@ export const populateSettingObject = (type, settingsList) => {
         case CLEAN:
             object = {
                 periodDSDownload: '',
+            }
+            break
+        case SPECIFIC_SETTINGS:
+            object = {
+                periodDSDownload:
+                    periodTypeConstants[settingsList[0].periodType].default,
             }
             break
         default:

--- a/src/modules/general/useGeneralForm.js
+++ b/src/modules/general/useGeneralForm.js
@@ -1,5 +1,6 @@
 import {
     androidSettingsDefault,
+    MANUAL,
     maxValues,
     RESERVED_VALUES,
     SMS_CONFIRMATION,
@@ -19,6 +20,10 @@ export const useGeneralForm = ({ setSubmitDataStore }) => {
         ...androidSettingsDefault,
         numberSmsToSend: '',
         numberSmsConfirmation: '',
+    })
+    const [manualAlertDialog, setManualAlert] = useState({
+        open: false,
+        selection: {},
     })
 
     const setInitialData = settings => {
@@ -47,14 +52,48 @@ export const useGeneralForm = ({ setSubmitDataStore }) => {
     }
 
     const onChangeSelect = (e, name) => {
-        setFields({ ...fields, [name]: e.selected })
-        setDisableSave(
-            errorNumber.numberSmsToSend || errorNumber.numberSmsConfirmation
-        )
-        setSubmitDataStore({
-            success: false,
-            error: false,
-        })
+        if (e.selected === MANUAL) {
+            handleManualAlert.open(e.selected, name)
+        } else {
+            setFields({ ...fields, [name]: e.selected })
+            setDisableSave(
+                errorNumber.numberSmsToSend || errorNumber.numberSmsConfirmation
+            )
+            setSubmitDataStore({
+                success: false,
+                error: false,
+            })
+        }
+    }
+
+    /**
+     * When Manual option is selected, an alert (dialog) should pop up
+     * */
+    const handleManualAlert = {
+        open: (selection, name) => {
+            setManualAlert({
+                selection: { name, value: selection },
+                open: true,
+            })
+        },
+        close: () => {
+            setManualAlert({ ...manualAlertDialog, open: false })
+        },
+        save: () => {
+            const { name, value } = manualAlertDialog.selection
+            setFields({ ...fields, [name]: value })
+            setDisableSave(
+                errorNumber.numberSmsToSend || errorNumber.numberSmsConfirmation
+            )
+            setSubmitDataStore({
+                success: false,
+                error: false,
+            })
+            setManualAlert({
+                open: false,
+                selection: {},
+            })
+        },
     }
 
     /**
@@ -134,10 +173,19 @@ export const useGeneralForm = ({ setSubmitDataStore }) => {
         setDisableSave,
         handleEncryptDialog,
         onChangeSelect,
+        handleManualAlert,
+        manualAlertDialog,
+        getInput: name => ({
+            name,
+            value: fields[name],
+            disabled: fields.disableAll,
+            onChange,
+        }),
         getPhoneNumber: name => ({
             name,
             value: fields[name],
             onChange,
+            onKeyUp: validatePhoneNumber,
             error: errorNumber[name],
             disabled: fields.disableAll,
         }),

--- a/src/modules/programs/parseValueBySettingType.js
+++ b/src/modules/programs/parseValueBySettingType.js
@@ -6,25 +6,26 @@ import {
     TEI_DOWNLOAD,
 } from '../../constants/program-settings'
 
+const convertToPositiveInteger = (value, maxValue) => {
+    return Math.min(
+        maxValue,
+        Math.max(0, isNaN(parseInt(value)) ? 0 : parseInt(value))
+    )
+}
+
 export const parseValueByType = (name, value) => {
     switch (name) {
         case TEI_DOWNLOAD:
-            value = value ? Math.min(maxValues.teiDownload, parseInt(value)) : 0
+            value = convertToPositiveInteger(value, maxValues.teiDownload)
             break
         case TEI_DB_TRIMMING:
-            value = value
-                ? Math.min(maxValues.teiDBTrimming, parseInt(value))
-                : 0
+            value = convertToPositiveInteger(value, maxValues.teiDBTrimming)
             break
         case EVENTS_DOWNLOAD:
-            value = value
-                ? Math.min(maxValues.eventsDownload, parseInt(value))
-                : 0
+            value = convertToPositiveInteger(value, maxValues.eventsDownload)
             break
         case EVENTS_DB_TRIMMING:
-            value = value
-                ? Math.min(maxValues.eventsDBTrimming, parseInt(value))
-                : 0
+            value = convertToPositiveInteger(value, maxValues.eventsDBTrimming)
             break
         default:
             break

--- a/src/pages/global-specific-settings.js
+++ b/src/pages/global-specific-settings.js
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { Button, ButtonStrip } from '@dhis2/ui-core'
+import { Button, ButtonStrip } from '@dhis2/ui'
 import i18n from '@dhis2/d2-i18n'
 import SettingsTable from '../components/settings-table/settings-table'
 import ProgramGlobalSettings from '../components/settings-table/program-global-settings'
@@ -13,8 +13,6 @@ import SaveErrorAlert from '../components/alert-bar/save-error-alert'
 
 import styles from '../styles/LayoutTitles.module.css'
 import buttonStyles from '../styles/Button.module.css'
-import layoutStyles from '../styles/Layout.module.css'
-
 import '@dhis2/d2-ui-core/css/Table.css'
 import ErrorAlert from '../components/alert-bar/error-alert'
 
@@ -89,14 +87,12 @@ const GlobalSpecificSettings = ({
                 </p>
 
                 {specificSettings.length > 0 && (
-                    <div className={layoutStyles.data__topMargin}>
-                        <TableActions
-                            states={states}
-                            columns={specificSettingTable.columnsTitle}
-                            rows={specificSettingList}
-                            menuActions={specificSettingTable.handleActions}
-                        />
-                    </div>
+                    <TableActions
+                        states={states}
+                        columns={specificSettingTable.columnsTitle}
+                        rows={specificSettingList}
+                        menuActions={specificSettingTable.handleActions}
+                    />
                 )}
 
                 <Button

--- a/src/pages/layout.js
+++ b/src/pages/layout.js
@@ -1,10 +1,9 @@
 import React, { useEffect, useState } from 'react'
 
 import { TwoPanel, MainContent } from '@dhis2/d2-ui-core'
-import { Paper } from '@material-ui/core'
+import { Card } from '@dhis2/ui'
 import { Route, Switch, HashRouter, Redirect } from 'react-router-dom'
 import menuSection from '../constants/menu-sections'
-
 import { D2Shim } from '../utils/D2Shim'
 import layoutStyles from '../styles/Layout.module.css'
 import DialogFirstLaunch from '../components/dialog/dialog-first-launch'
@@ -61,7 +60,7 @@ const Layout = () => {
             <TwoPanel mainStyle={styles.twoPanelMain}>
                 <SideBar />
                 <MainContent>
-                    <Paper className={layoutStyles.paper__layout}>
+                    <Card className={layoutStyles.paper__layout}>
                         <Switch>
                             <Route path="/" exact>
                                 <D2Shim>
@@ -92,7 +91,7 @@ const Layout = () => {
                                 <PageNotFound />
                             </Route>
                         </Switch>
-                    </Paper>
+                    </Card>
                 </MainContent>
             </TwoPanel>
         </HashRouter>

--- a/src/styles/Form.module.css
+++ b/src/styles/Form.module.css
@@ -1,0 +1,11 @@
+.row {
+    display: flex;
+}
+
+.row + .row {
+    margin-top: 20px;
+}
+
+.rowMargin {
+    margin-top: 20px;
+}

--- a/src/styles/TableActions.module.css
+++ b/src/styles/TableActions.module.css
@@ -1,0 +1,39 @@
+.container {
+    display: grid;
+    grid-template-columns: 2fr 0.3fr;
+    margin-top: 20px;
+}
+
+.fullContainer {
+    grid-template-columns: 2fr;
+}
+
+.wrapper {
+    box-shadow: 0 0 1px 0 rgba(64, 75, 90, 0.6) !important;
+}
+
+.wrapper + .wrapper {
+    margin-top: 20px;
+}
+
+.parent {
+    display: grid;
+    grid-template-columns: 2fr 1fr;
+    margin: 15px;
+}
+
+.parent > div:last-child {
+    justify-self: end;
+    align-self: center;
+}
+
+.title {
+    color: var(--colors-grey900);
+    font-weight: 500;
+    font-size: 0.95rem;
+    margin-bottom: 8px;
+}
+
+.subtitle {
+    color: var(--colors-grey700);
+}

--- a/src/styles/TableSettings.module.css
+++ b/src/styles/TableSettings.module.css
@@ -1,0 +1,20 @@
+
+.parent {
+    display: grid;
+    grid-template-columns: 1fr minmax(100px, 20%);
+}
+
+.parent > div{
+    align-self: center;
+}
+
+.parent > div:first-child{
+    align-self: center;
+    font-weight: normal;
+    font-size: 0.9rem;
+    color: var(--colors-grey900);
+}
+
+.parent > div:last-child {
+    justify-self: end;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1689,6 +1689,13 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
+"@babel/runtime@^7.10.0":
+  version "7.11.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
+  integrity sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.3.4", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.4":
   version "7.8.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.8.0.tgz#8c81711517c56b3d00c6de706b0fb13dc3531549"
@@ -2060,12 +2067,62 @@
   dependencies:
     prop-types "^15"
 
+"@dhis2/prop-types@^1.6.4":
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/@dhis2/prop-types/-/prop-types-1.6.4.tgz#ec4d256c9440d4d00071524422a727c61ddaa6f6"
+  integrity sha512-qkVj8OuyjDmSxzYDlCWZllvC9hIbrIImMp79/U5CVsIRbjUF0zA/tfbv4rWnsWALmwEHOQFbzl5GnO5D8RNneA==
+  dependencies:
+    prop-types "^15"
+
+"@dhis2/ui-constants@5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui-constants/-/ui-constants-5.5.0.tgz#514505325a538e41967bc583388befebc5caede0"
+  integrity sha512-Tfl1tUvudi73yjKXPJaOzW6GDKs3Uau7AOaJkMNgsQBhQPOobzbu6YB0uQPcKxAyFZXE6XtJef3Sjl6KmTWiow==
+  dependencies:
+    "@dhis2/prop-types" "^1.6.4"
+
+"@dhis2/ui-core@5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui-core/-/ui-core-5.5.0.tgz#05d06e5d2120a5ea70854af8f4c5db8a725aeae9"
+  integrity sha512-Onn2q6aeU728ROSCyFxDogOcQQT62CJQ6RHUtW0xvtJRIfA5vhSRl9VDQcPU0i2GNvdy6bdrqHuq49Zi6UqnoQ==
+  dependencies:
+    "@dhis2/prop-types" "^1.6.4"
+    "@popperjs/core" "^2.4.2"
+    classnames "^2.2.6"
+    react-popper "^2.2.3"
+    resize-observer-polyfill "^1.5.1"
+
 "@dhis2/ui-core@^4.6.1":
   version "4.6.1"
   resolved "https://registry.yarnpkg.com/@dhis2/ui-core/-/ui-core-4.6.1.tgz#62677590b3b32322dfa014b006e6226b637f0162"
   integrity sha512-85ubddhmSRjDFPZqtSoTOZiPnfzHU1CyFyTXYmar/3lr8zl4mzY7aKScsEsTtJRWpN8ie86LWRqdGpbrV98VcQ==
   dependencies:
     "@dhis2/prop-types" "^1.5.0"
+    classnames "^2.2.6"
+
+"@dhis2/ui-forms@5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui-forms/-/ui-forms-5.5.0.tgz#681ef4f69c5598a930561b716e72f336a7430fed"
+  integrity sha512-KPhWHhM9AXkvSg74HU7o+EZDI5CVOh72GiXoW70QNBEQV8as3UMN9P83JvavsGI6UBBNHo1qjYELRldYS+sslA==
+  dependencies:
+    "@dhis2/prop-types" "^1.6.4"
+    classnames "^2.2.6"
+    final-form "^4.20.0"
+    react-final-form "^6.5.0"
+
+"@dhis2/ui-icons@5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui-icons/-/ui-icons-5.5.0.tgz#d3946bf6cea2670eaac0ad0d413eafc30b9cffb2"
+  integrity sha512-mpvXLGaB212/H8sHPoXq8y14XIXoBTXpI4mWOpr/FM2pk+vOCj2OxSqYi2pe8nRpN4pWjc2aeo6s21Dro6xLwA==
+  dependencies:
+    "@dhis2/prop-types" "^1.6.4"
+
+"@dhis2/ui-widgets@5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui-widgets/-/ui-widgets-5.5.0.tgz#0c942a3ff0c42e3bfc6015d33a01e6e6a4362bc8"
+  integrity sha512-xX8C0o7pKjxSNGpk88aNTXcIsKHBbs09iX4PGZJGAdkZiYYwnmau2dVUJc4yjsTy9CAETW95zEPXvPz3zQvGEg==
+  dependencies:
+    "@dhis2/prop-types" "^1.6.4"
     classnames "^2.2.6"
 
 "@dhis2/ui-widgets@^2.0.4":
@@ -2075,6 +2132,17 @@
   dependencies:
     "@dhis2/prop-types" "^1.5"
     classnames "^2.2.6"
+
+"@dhis2/ui@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui/-/ui-5.5.0.tgz#f013c4aa78c625fd2dacbd640dfb445dabfec692"
+  integrity sha512-F319H+MozGqRo6i4iS6gS4yxZsW60MnmVPUzbWB/UxmB6hWXB3QFQpVnuH8sZA5jx3/NoW1Qm6F7uKEqmjVkdQ==
+  dependencies:
+    "@dhis2/ui-constants" "5.5.0"
+    "@dhis2/ui-core" "5.5.0"
+    "@dhis2/ui-forms" "5.5.0"
+    "@dhis2/ui-icons" "5.5.0"
+    "@dhis2/ui-widgets" "5.5.0"
 
 "@emotion/babel-utils@^0.6.4":
   version "0.6.10"
@@ -2384,6 +2452,11 @@
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
+
+"@popperjs/core@^2.4.2":
+  version "2.4.4"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.4.4.tgz#11d5db19bd178936ec89cd84519c4de439574398"
+  integrity sha512-1oO6+dN5kdIA3sKPZhRGJTfGVP4SWV6KqlMOwry4J3HfyD68sl/3KmG7DeYUzvN+RbhXDnv/D8vNNB8168tAMg==
 
 "@reach/auto-id@^0.2.0":
   version "0.2.0"
@@ -6392,6 +6465,13 @@ fill-range@^7.0.1:
   integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
   dependencies:
     to-regex-range "^5.0.1"
+
+final-form@^4.20.0:
+  version "4.20.1"
+  resolved "https://registry.yarnpkg.com/final-form/-/final-form-4.20.1.tgz#525a7f7f27f55c28d8994b157b24d6104fc560e9"
+  integrity sha512-IIsOK3JRxJrN72OBj7vFWZxtGt3xc1bYwJVPchjVWmDol9DlzMSAOPB+vwe75TUYsw1JaH0fTQnIgwSQZQ9Acg==
+  dependencies:
+    "@babel/runtime" "^7.10.0"
 
 finalhandler@~1.1.2:
   version "1.1.2"
@@ -11660,6 +11740,18 @@ react-event-listener@^0.6.2:
     prop-types "^15.6.0"
     warning "^4.0.1"
 
+react-fast-compare@^3.0.1:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
+  integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
+
+react-final-form@^6.5.0:
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/react-final-form/-/react-final-form-6.5.1.tgz#baf798129d459c669cfda5ce60a77801ef52badc"
+  integrity sha512-+Hzd9PqYY1Cv3MnWzw64QOl5BjC5BtSDakx+N7Re49r0FASdFhgpXLFFCJ31fvegq2euP6hz6Ow9K6XM9BSqCA==
+  dependencies:
+    "@babel/runtime" "^7.10.0"
+
 react-input-autosize@^2.2.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/react-input-autosize/-/react-input-autosize-2.2.2.tgz#fcaa7020568ec206bc04be36f4eb68e647c4d8c2"
@@ -11676,6 +11768,14 @@ react-lifecycles-compat@^3.0.2, react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
+
+react-popper@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-2.2.3.tgz#33d425fa6975d4bd54d9acd64897a89d904b9d97"
+  integrity sha512-mOEiMNT1249js0jJvkrOjyHsGvqcJd3aGW/agkiMoZk3bZ1fXN1wQszIQSjHIai48fE67+zwF8Cs+C4fWqlfjw==
+  dependencies:
+    react-fast-compare "^3.0.1"
+    warning "^4.0.2"
 
 react-router-dom@^5.0.1:
   version "5.1.2"
@@ -11978,6 +12078,11 @@ regenerator-runtime@^0.13.2, regenerator-runtime@^0.13.3:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz#7cf6a77d8f5c6f60eb73c5fc1955b2ceb01e6bf5"
   integrity sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==
 
+regenerator-runtime@^0.13.4:
+  version "0.13.7"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz#cac2dacc8a1ea675feaabaeb8ae833898ae46f55"
+  integrity sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==
+
 regenerator-transform@^0.14.0:
   version "0.14.1"
   resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.14.1.tgz#3b2fce4e1ab7732c08f665dfdb314749c7ddd2fb"
@@ -12195,6 +12300,11 @@ reserved-words@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/reserved-words/-/reserved-words-0.1.2.tgz#00a0940f98cd501aeaaac316411d9adc52b31ab1"
   integrity sha1-AKCUD5jNUBrqqsMWQR2a3FKzGrE=
+
+resize-observer-polyfill@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
+  integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==
 
 resolve-cwd@^2.0.0:
   version "2.0.0"
@@ -14181,7 +14291,7 @@ warning@^3.0.0:
   dependencies:
     loose-envify "^1.0.0"
 
-warning@^4.0.1:
+warning@^4.0.1, warning@^4.0.2:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
   integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==


### PR DESCRIPTION
This version has:

- Migration of components: from Material design to UI Library.
- Add a Manual option to data and metadata sync.


PR | Description
-- | --
#52 | Change labels for metadata and data options
#53 | Migrate material design to UI library for general settings
#54 | Migrate material design to UI library for dataset and programs
#55 | Add TEI reserved value to run sync test
#56 | Add manual option to metadata and data sync
#57 | Update app version to v1.1
#58 | Change manual dialog text


**General Settings:**
![image](https://user-images.githubusercontent.com/29384664/106314105-411bdb00-6237-11eb-9d45-5eac9314ab00.png)

**Program Settings:**
![image](https://user-images.githubusercontent.com/29384664/106314514-da4af180-6237-11eb-9129-96fb7747fca2.png)

**Data sets Settings:**
![image](https://user-images.githubusercontent.com/29384664/106314984-8987c880-6238-11eb-800d-a7451c3c3469.png)

![image](https://user-images.githubusercontent.com/29384664/106315113-c5229280-6238-11eb-9bbf-8d4eccc24c6f.png)

**Manual Option:**
![image](https://user-images.githubusercontent.com/29384664/106315243-f8652180-6238-11eb-9a25-5106fed55e79.png)

