### PR TITLE
feat: [DHIS2-9135] Synchronization User sync test change user search field

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-07-15T17:14:24.104Z\n"
-"PO-Revision-Date: 2021-07-15T17:14:24.104Z\n"
+"POT-Creation-Date: 2021-08-05T14:42:31.584Z\n"
+"PO-Revision-Date: 2021-08-05T14:42:31.584Z\n"
 
 msgid "Edit"
 msgstr ""
@@ -691,4 +691,13 @@ msgid ""
 msgstr ""
 
 msgid "program"
+msgstr ""
+
+msgid "User Sync Test"
+msgstr ""
+
+msgid "Insert"
+msgstr ""
+
+msgid "Search by user"
 msgstr ""

--- a/src/constants/menu-sections.js
+++ b/src/constants/menu-sections.js
@@ -1,11 +1,11 @@
 import React from 'react'
 import i18n from '@dhis2/d2-i18n'
-import UserSyncTestContainer from '../components/sections/user-sync-test/user-sync-test-container'
 import Home from '../pages/Home/Home'
 import GeneralSettings from '../pages/General/GeneralSettings'
 import GlobalSettings from '../pages/Synchronization/Global/GlobalSettings'
 import ProgramSyncSettings from '../pages/Synchronization/Programs/ProgramSyncSettings'
 import DatasetSyncSettings from '../pages/Synchronization/Datasets/DatasetSyncSettings'
+import UserSyncTest from '../pages/Synchronization/UserSyncTest/UserSyncTest'
 import HomeAppearance from '../pages/Appearance/Home/HomeAppearance'
 import ProgramsAppearance from '../pages/Appearance/Programs/ProgramsAppearance'
 import DatasetsAppearance from '../pages/Appearance/Datasets/DatasetsAppearance'
@@ -64,7 +64,7 @@ export const syncPages = [
         code: 'user-sync-test',
         label: i18n.t('User sync test'),
         path: '/sync/user-sync-test',
-        component: <UserSyncTestContainer />,
+        component: <UserSyncTest />,
         linkText: i18n.t('Run user sync test'),
         description: i18n.t(
             'Check how much data a user downloads when syncing'

--- a/src/pages/Synchronization/UserSyncTest/RunTest.js
+++ b/src/pages/Synchronization/UserSyncTest/RunTest.js
@@ -1,0 +1,26 @@
+import React, { useState } from 'react'
+import i18n from '@dhis2/d2-i18n'
+import TestTable from './TestTable'
+import { AddNewSetting } from '../../../components/field'
+
+const RunTest = ({ disabled }) => {
+    const [runTest, setRunTest] = useState(false)
+
+    const testUser = () => {
+        setRunTest(true)
+    }
+
+    return (
+        <>
+            {runTest && <TestTable />}
+
+            <AddNewSetting
+                label={i18n.t('Run test')}
+                disable={disabled}
+                onClick={testUser}
+            />
+        </>
+    )
+}
+
+export default RunTest

--- a/src/pages/Synchronization/UserSyncTest/TestTable.js
+++ b/src/pages/Synchronization/UserSyncTest/TestTable.js
@@ -1,0 +1,62 @@
+import React from 'react'
+import cx from 'classnames'
+import i18n from '@dhis2/d2-i18n'
+import {
+    DataTable,
+    TableBody,
+    DataTableRow,
+    DataTableCell,
+    CircularLoader,
+} from '@dhis2/ui'
+import { testAndroidDataConstants } from '../../../constants/test-android'
+import classes from './TestTable.module.css'
+
+const TestResult = ({ load, state, test }) => (
+    <>
+        {load ? (
+            <CircularLoader small />
+        ) : (
+            <p
+                className={cx(classes.subItemTitle, {
+                    [classes.maxValue]:
+                        state[test.state] >= state[test.maxValueState],
+                })}
+            >
+                {state[test.state]}
+            </p>
+        )}
+    </>
+)
+
+const TestRow = ({ test }) => (
+    <DataTableRow>
+        <DataTableCell large className={classes.tableCell}>
+            20
+        </DataTableCell>
+        <DataTableCell large className={classes.tableCell}>
+            {test.title}
+        </DataTableCell>
+        <DataTableCell large className={classes.tableCell}>
+            {i18n.t('Recommended maximum: {{maxValue}}', {
+                nsSeparator: '---',
+                maxValue: test.maxValue,
+            })}
+        </DataTableCell>
+    </DataTableRow>
+)
+
+const TestTable = () => {
+    return (
+        <div className={classes.topMargin}>
+            <DataTable className={classes.table}>
+                <TableBody>
+                    {testAndroidDataConstants.map(test => (
+                        <TestRow test={test} key={test.state} />
+                    ))}
+                </TableBody>
+            </DataTable>
+        </div>
+    )
+}
+
+export default TestTable

--- a/src/pages/Synchronization/UserSyncTest/TestTable.module.css
+++ b/src/pages/Synchronization/UserSyncTest/TestTable.module.css
@@ -1,0 +1,23 @@
+.table {
+    border: none !important;
+    background: none;
+    max-width: 1000px;
+}
+
+.tableCell {
+    background: none !important;
+}
+
+.subItemTitle {
+    color: #494949;
+    padding: 0 10px;
+    font-size: 0.8rem;
+}
+
+.maxValue {
+    color: red;
+}
+
+.topMargin {
+    margin-top: var(--spacers-dp24);
+}

--- a/src/pages/Synchronization/UserSyncTest/UserSearch.js
+++ b/src/pages/Synchronization/UserSyncTest/UserSearch.js
@@ -1,0 +1,21 @@
+import React, { useEffect, useState } from 'react'
+import ItemSelector from './searchField/ItemSelector'
+import RunTest from './RunTest'
+
+const UserSearch = () => {
+    const [disableRun, setDisableRun] = useState(true)
+    const [userSelected, setUser] = useState()
+
+    useEffect(() => {
+        userSelected ? setDisableRun(false) : setDisableRun(true)
+    }, [userSelected])
+
+    return (
+        <>
+            <ItemSelector selection={setUser} />
+            <RunTest disabled={disableRun} />
+        </>
+    )
+}
+
+export default UserSearch

--- a/src/pages/Synchronization/UserSyncTest/UserSyncTest.js
+++ b/src/pages/Synchronization/UserSyncTest/UserSyncTest.js
@@ -1,0 +1,20 @@
+import React from 'react'
+import i18n from '@dhis2/d2-i18n'
+import Page from '../../../components/page/Page'
+import UserSearch from './UserSearch'
+
+const UserSyncTest = () => {
+    return (
+        <Page
+            title={i18n.t('User Sync Test')}
+            desc={i18n.t(
+                'Check the amount of data a user would sync to their device.'
+            )}
+            unsavedChanges={false}
+        >
+            <UserSearch />
+        </Page>
+    )
+}
+
+export default UserSyncTest

--- a/src/pages/Synchronization/UserSyncTest/searchField/ContentMenuItem.js
+++ b/src/pages/Synchronization/UserSyncTest/searchField/ContentMenuItem.js
@@ -1,0 +1,14 @@
+import React from 'react'
+import { MenuItem } from '@dhis2/ui'
+import PropTypes from 'prop-types'
+
+const ContentMenuItem = ({ name, onInsert }) => (
+    <MenuItem onClick={onInsert} label={name} dataTest={`menu-item-${name}`} />
+)
+
+ContentMenuItem.propTypes = {
+    name: PropTypes.string,
+    onInsert: PropTypes.func,
+}
+
+export default ContentMenuItem

--- a/src/pages/Synchronization/UserSyncTest/searchField/ItemSearchField.js
+++ b/src/pages/Synchronization/UserSyncTest/searchField/ItemSearchField.js
@@ -1,0 +1,37 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import i18n from '@dhis2/d2-i18n'
+import { InputField, Button } from '@dhis2/ui'
+import classes from './styles/ItemSearchField.module.css'
+
+const ItemSearchField = ({ value, disabled, onFocus, onChange, onClear }) => (
+    <div>
+        <InputField
+            name="User item search"
+            label={i18n.t('User')}
+            placeholder={i18n.t('Search by user')}
+            type="text"
+            onChange={onChange}
+            onFocus={onFocus}
+            value={value}
+            disabled={disabled}
+            dataTest="item-search"
+            inputWidth="400px"
+            className={classes.field}
+        />
+
+        <Button small className={classes.field} onClick={onClear}>
+            Clear
+        </Button>
+    </div>
+)
+
+ItemSearchField.propTypes = {
+    disabled: PropTypes.bool,
+    value: PropTypes.string,
+    onChange: PropTypes.func,
+    onClear: PropTypes.func,
+    onFocus: PropTypes.func,
+}
+
+export default ItemSearchField

--- a/src/pages/Synchronization/UserSyncTest/searchField/ItemSelector.js
+++ b/src/pages/Synchronization/UserSyncTest/searchField/ItemSelector.js
@@ -1,0 +1,101 @@
+import React, { createRef, useEffect, useState } from 'react'
+import { Popover, FlyoutMenu } from '@dhis2/ui'
+import { useDataEngine } from '@dhis2/app-runtime'
+import ItemSearchField from './ItemSearchField'
+import ContentMenuItem from './ContentMenuItem'
+import { getUserQuery } from '../userSyncQueries'
+import useDebounce from '../../../../utils/useDebounce'
+import classes from './styles/ItemSelector.module.css'
+
+const ItemSelector = ({ selection }) => {
+    const [isOpen, setIsOpen] = useState(false)
+    const [filter, setFilter] = useState('')
+    const [items, setItems] = useState(null)
+    const [maxOptions, setMaxOptions] = useState(new Set())
+    const [disableField, setDisable] = useState(false)
+    const dataEngine = useDataEngine()
+    const debouncedFilterText = useDebounce(filter, 350)
+
+    useEffect(() => {
+        const query = getUserQuery(debouncedFilterText, Array.from(maxOptions))
+
+        dataEngine.query({ items: query }).then(res => {
+            setItems(res.items.users)
+        })
+    }, [debouncedFilterText, maxOptions])
+
+    const closeMenu = () => {
+        setIsOpen(false)
+        setFilter('')
+        selection('')
+        setMaxOptions(new Set())
+    }
+
+    const openMenu = () => setIsOpen(true)
+
+    const addItem = item => () => {
+        setDisable(true)
+        closeMenu()
+        setFilter(item.name)
+        selection(item.id)
+    }
+
+    const clearField = () => {
+        closeMenu()
+        setDisable(false)
+    }
+
+    const getMenus = () => {
+        const displayItems = items.slice(0, 5)
+        return displayItems.map(item => (
+            <ContentMenuItem
+                key={item.id || item.key}
+                name={item.displayName || item.name}
+                onInsert={addItem(item)}
+                type={item.type}
+                valid={item.valid}
+            />
+        ))
+    }
+
+    const getItems = () => getMenus()
+
+    const updateFilter = ({ value }) => setFilter(value)
+
+    const inputRef = createRef()
+
+    return (
+        <>
+            <span ref={inputRef}>
+                <ItemSearchField
+                    value={filter}
+                    onChange={updateFilter}
+                    onFocus={openMenu}
+                    onClear={clearField}
+                    disabled={disableField}
+                />
+            </span>
+            {isOpen && (
+                <Popover
+                    reference={inputRef}
+                    placement="bottom-start"
+                    onClickOutside={closeMenu}
+                    arrow={false}
+                    maxWidth={400}
+                >
+                    <div className={classes.popover}>
+                        <FlyoutMenu
+                            className={classes.menu}
+                            dataTest="item-menu"
+                            maxWidth="400px"
+                        >
+                            {getItems()}
+                        </FlyoutMenu>
+                    </div>
+                </Popover>
+            )}
+        </>
+    )
+}
+
+export default ItemSelector

--- a/src/pages/Synchronization/UserSyncTest/searchField/styles/ItemSearchField.module.css
+++ b/src/pages/Synchronization/UserSyncTest/searchField/styles/ItemSearchField.module.css
@@ -1,0 +1,3 @@
+.field {
+    display: inline-block;
+}

--- a/src/pages/Synchronization/UserSyncTest/searchField/styles/ItemSelector.module.css
+++ b/src/pages/Synchronization/UserSyncTest/searchField/styles/ItemSelector.module.css
@@ -1,0 +1,9 @@
+.menu {
+    width: 400px;
+}
+
+@media only screen and (max-width: 480px) {
+    .popover {
+        display: none;
+    }
+}

--- a/src/pages/Synchronization/UserSyncTest/userSyncQueries.js
+++ b/src/pages/Synchronization/UserSyncTest/userSyncQueries.js
@@ -1,0 +1,41 @@
+import { useDataQuery } from '@dhis2/app-runtime'
+import { useGetSyncDataStore } from '../SyncDatastoreQuery'
+import { getGeneralKeyQuery } from '../../General/generalDatastoreApi'
+
+export const getUserQuery = (query = '', maxItems = []) => {
+    return {
+        resource: `users`,
+        params: {
+            query,
+            count: 11,
+            max: maxItems,
+            fields: 'id,name,userCredentials,userGroups',
+            order: 'name:asc',
+        },
+    }
+}
+
+/**
+ *
+ * Get values from datastore
+ * Keys: generalSettings & synchronization
+ * values:
+ *  programSettings = {
+ *      globalSettings
+ *      specificSettings
+ *  }
+ *  general => reservedValues
+ *
+ * */
+
+export const useReadSettings = () => {
+    const { data } = useDataQuery(getGeneralKeyQuery)
+    const { load, errorSyncing, programSettings } = useGetSyncDataStore()
+    return {
+        loading: load,
+        errorSettings: errorSyncing,
+        reservedValues: data && data.generalSettings.reservedValues,
+        globalSettings: programSettings && programSettings.globalSettings,
+        specificSettings: programSettings && programSettings.specificSettings,
+    }
+}

--- a/src/utils/useDebounce.js
+++ b/src/utils/useDebounce.js
@@ -1,0 +1,16 @@
+import { useState, useEffect } from 'react'
+
+const useDebounce = (value, delay) => {
+    const [debouncedValue, setDebouncedValue] = useState(value)
+    useEffect(() => {
+        const handler = setTimeout(() => {
+            setDebouncedValue(value)
+        }, delay)
+        return () => {
+            clearTimeout(handler)
+        }
+    }, [value, delay])
+    return debouncedValue
+}
+
+export default useDebounce


### PR DESCRIPTION
The current PR has:

- user search field, the options are updated with the query response
- migrate components from materialize to dhis2/ui
- create a basic table to show the test result

Note: This PR doesn't have sync tests, only shows the layout

_User sync test section page_
![image](https://user-images.githubusercontent.com/29384664/128426422-d58ae62f-a513-4b6f-bbcd-9977d3b9b60b.png)

_User selected and table with tests_
![image](https://user-images.githubusercontent.com/29384664/128426507-a5408988-edad-46b2-a237-d92255fde73b.png)


