### PR TITLE
feat: show and delete group and visualizations

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-11-04T20:09:58.176Z\n"
-"PO-Revision-Date: 2021-11-04T20:09:58.176Z\n"
+"POT-Creation-Date: 2021-11-10T06:32:26.798Z\n"
+"PO-Revision-Date: 2021-11-10T06:32:26.798Z\n"
 
 msgid "Edit"
 msgstr ""
@@ -23,6 +23,18 @@ msgid "Failed to get data from Data Store"
 msgstr ""
 
 msgid "Settings were successfully saved"
+msgstr ""
+
+msgid "Delete Group"
+msgstr ""
+
+msgid "Visualization"
+msgstr ""
+
+msgid "Are you sure you want to delete {{elementName}} visualization group?"
+msgstr ""
+
+msgid "Visualization Group"
 msgstr ""
 
 msgid "Data Element"
@@ -137,6 +149,9 @@ msgid "Are you sure you want to delete {{name}} {{typeName}} settings?"
 msgstr ""
 
 msgid "Cancel"
+msgstr ""
+
+msgid "Delete {{element}}"
 msgstr ""
 
 msgid "Disable all settings"
@@ -315,9 +330,6 @@ msgstr ""
 msgid "Something went wrong when loading the data"
 msgstr ""
 
-msgid "No {{type}} Visualization found"
-msgstr ""
-
 msgid "It looks like there aren't any configured visualizations."
 msgstr ""
 
@@ -340,24 +352,6 @@ msgid "User"
 msgstr ""
 
 msgid "Maximum number of periods to download data sets for"
-msgstr ""
-
-msgid "Period"
-msgstr ""
-
-msgid "Organisation Unit"
-msgstr ""
-
-msgid "Sync status"
-msgstr ""
-
-msgid "Category Combo"
-msgstr ""
-
-msgid "Date"
-msgstr ""
-
-msgid "Assigned to me"
 msgstr ""
 
 msgid "Overview"
@@ -567,6 +561,9 @@ msgstr ""
 msgid "Manage visualizations for program."
 msgstr ""
 
+msgid "Could not find any program visualisations"
+msgstr ""
+
 msgid "Add Program Visualization"
 msgstr ""
 
@@ -605,12 +602,39 @@ msgstr ""
 msgid "Add a Data set Settings"
 msgstr ""
 
+msgid "Period"
+msgstr ""
+
+msgid "Organisation Unit"
+msgstr ""
+
+msgid "Sync status"
+msgstr ""
+
+msgid "Category Combo"
+msgstr ""
+
+msgid "Filters: {{filterList}}"
+msgstr ""
+
+msgid "No Filters"
+msgstr ""
+
+msgid "Sync Status"
+msgstr ""
+
 msgid "Home Screen"
 msgstr ""
 
 msgid ""
 "Customize the available filters and sorting options for the home screen. "
 "Filters and sorting options set here will only affect the home screen."
+msgstr ""
+
+msgid "Date"
+msgstr ""
+
+msgid "Assigned to me"
 msgstr ""
 
 msgid "Program specific settings"
@@ -643,19 +667,10 @@ msgstr ""
 msgid "Follow up"
 msgstr ""
 
-msgid "Filters: {{filterList}}"
-msgstr ""
-
-msgid "No Filters"
-msgstr ""
-
 msgid "Enrollment Status"
 msgstr ""
 
 msgid "Event Status"
-msgstr ""
-
-msgid "Sync Status"
 msgstr ""
 
 msgid "This will disable and remove all General, Program and Data set settings."

--- a/src/components/analyticVisualization/VisualizationTable/GroupVisualizationRow.js
+++ b/src/components/analyticVisualization/VisualizationTable/GroupVisualizationRow.js
@@ -32,8 +32,7 @@ export const GroupVisualizationRow = ({
     )
 
     const createGroupRow = () => {
-        return Object.keys(group.groups).map((item, i) => {
-            const groupRow = group.groups[item]
+        return Object.entries(group.groups).map(([item, groupRow], i) => {
             const groupName =
                 groupRow[0].group.name === 'default'
                     ? ''

--- a/src/components/analyticVisualization/VisualizationTable/GroupVisualizationRow.js
+++ b/src/components/analyticVisualization/VisualizationTable/GroupVisualizationRow.js
@@ -1,0 +1,84 @@
+import React, { useState } from 'react'
+import i18n from '@dhis2/d2-i18n'
+import PropTypes from '@dhis2/prop-types'
+import {
+    Button,
+    DataTable,
+    DataTableBody,
+    DataTableCell,
+    DataTableRow,
+} from '@dhis2/ui'
+import { VisualizationRow } from './VisualizationRow'
+import styles from './VisualizationTable.module.css'
+
+export const GroupVisualizationRow = ({
+    group,
+    deleteVisualization,
+    deleteGroup,
+    element,
+    disabled,
+}) => {
+    const [openRowIndex, setOpenRowIndex] = useState(null)
+
+    const toggleOpenRow = index =>
+        setOpenRowIndex(openRowIndex === index ? null : index)
+
+    const expandableContent = item => (
+        <VisualizationRow
+            visualizationList={item}
+            deleteVisualization={deleteVisualization}
+            disabled={disabled}
+        />
+    )
+
+    const createGroupRow = () => {
+        return Object.keys(group.groups).map((item, i) => {
+            const groupRow = group.groups[item]
+            const groupName =
+                groupRow[0].group.name === 'default'
+                    ? ''
+                    : groupRow[0].group.name
+            const elementId = groupRow[0][element]
+
+            return (
+                <DataTableRow
+                    expanded={openRowIndex === i}
+                    onExpandToggle={() => toggleOpenRow(i)}
+                    expandableContent={expandableContent(groupRow)}
+                    key={i}
+                >
+                    <DataTableCell className={styles.tableSubtitle}>
+                        {groupName}
+                    </DataTableCell>
+                    <DataTableCell />
+                    <DataTableCell align="center">
+                        <Button
+                            small
+                            secondary
+                            onClick={() => deleteGroup(item, elementId)}
+                            disabled={disabled}
+                        >
+                            {i18n.t('Delete Group')}
+                        </Button>
+                    </DataTableCell>
+                </DataTableRow>
+            )
+        })
+    }
+
+    return (
+        <div className={styles.rowPadding}>
+            <DataTable className={styles.table}>
+                <DataTableBody>{createGroupRow()}</DataTableBody>
+            </DataTable>
+        </div>
+    )
+}
+
+GroupVisualizationRow.propTypes = {
+    group: PropTypes.object,
+    deleteGroup: PropTypes.func,
+    deleteVisualization: PropTypes.func,
+    disabled: PropTypes.bool,
+    element: PropTypes.string,
+}

--- a/src/components/analyticVisualization/VisualizationTable/ProgramTable.js
+++ b/src/components/analyticVisualization/VisualizationTable/ProgramTable.js
@@ -1,0 +1,117 @@
+import React, { useState } from 'react'
+import i18n from '@dhis2/d2-i18n'
+import PropTypes from '@dhis2/prop-types'
+import { VisualizationTable } from './VisualizationTable'
+import DialogDelete from '../../dialog/DialogDelete'
+import DialogDeleteElement from '../../dialog/DialogDeleteElement'
+import { removeSettingsFromList } from '../../../utils/utils'
+import { removeElement, updateGroup } from './helper'
+
+export const ProgramTable = ({ rows, changeRows, disabled }) => {
+    const [openDeleteDialog, setOpenDialog] = useState(false)
+    const [specificSetting, setSpecificSetting] = useState({})
+    const [group, setGroup] = useState([])
+    const [openDeleteGroup, setDeleteGroup] = useState(false)
+    const [elementName, setName] = useState()
+
+    const deleteRow = (row, group) => {
+        setSpecificSetting(row)
+        setGroup(group)
+        setName(row.name)
+        setOpenDialog(true)
+    }
+
+    const handleDialogClose = () => {
+        setOpenDialog(false)
+        setSpecificSetting({})
+        setGroup([])
+        setName('')
+    }
+
+    const handleDelete = () => {
+        const updatedList = removeSettingsFromList(specificSetting, group)
+        const { program, group: programGroup } = specificSetting
+        const updatedGroups = updateGroup(
+            rows[program].groups,
+            programGroup.id,
+            updatedList
+        )
+
+        changeRows({
+            ...rows,
+            [program]: {
+                ...rows[program],
+                groups: updatedGroups,
+            },
+        })
+        handleDialogClose()
+    }
+
+    const handleDeleteGroup = () => {
+        const visualizations = Object.assign({}, rows)
+        const currentProgramGroups = visualizations[group].groups
+        const updatedGroupList = removeElement(
+            currentProgramGroups,
+            specificSetting
+        )
+
+        changeRows({
+            ...rows,
+            [group]: {
+                ...rows[group],
+                groups: updatedGroupList,
+            },
+        })
+        handleCloseDeleteGroup()
+    }
+
+    const handleCloseDeleteGroup = () => {
+        setDeleteGroup(false)
+        setSpecificSetting({})
+        setGroup([])
+        setName('')
+    }
+
+    const deleteGroup = (item, programId) => {
+        const name = rows[programId].groups[item][0].group.name
+        setName(name)
+        setSpecificSetting(item)
+        setGroup(programId)
+        setDeleteGroup(true)
+    }
+
+    return (
+        <>
+            <VisualizationTable
+                element="program"
+                rows={rows}
+                deleteVisualization={deleteRow}
+                deleteGroup={deleteGroup}
+                disabled={disabled}
+            />
+            <DialogDelete
+                open={openDeleteDialog}
+                name={elementName}
+                onHandleDelete={handleDelete}
+                onHandleClose={handleDialogClose}
+                typeName={i18n.t('Visualization')}
+            />
+            <DialogDeleteElement
+                open={openDeleteGroup}
+                onHandleClose={handleCloseDeleteGroup}
+                onHandleDelete={handleDeleteGroup}
+                text={i18n.t(
+                    'Are you sure you want to delete {{elementName}} visualization group?',
+                    { elementName: elementName }
+                )}
+                element={i18n.t('Visualization Group')}
+            />
+        </>
+    )
+}
+
+ProgramTable.propTypes = {
+    disabled: PropTypes.bool,
+    rows: PropTypes.object,
+    changeRows: PropTypes.func,
+}

--- a/src/components/analyticVisualization/VisualizationTable/VisualizationRow.js
+++ b/src/components/analyticVisualization/VisualizationTable/VisualizationRow.js
@@ -1,0 +1,44 @@
+import React from 'react'
+import i18n from '@dhis2/d2-i18n'
+import PropTypes from '@dhis2/prop-types'
+import { Button } from '@dhis2/ui'
+import cx from 'classnames'
+import styles from './VisualizationTable.module.css'
+
+export const VisualizationRow = ({
+    visualizationList,
+    deleteVisualization,
+    disabled,
+}) => (
+    <>
+        {visualizationList.map(visualization => (
+            <div
+                className={cx([styles.boxContainer, styles.rowContainer])}
+                key={visualization.id}
+            >
+                <p> {visualization.name} </p>
+                <div>
+                    <Button
+                        small
+                        secondary
+                        onClick={() => {
+                            deleteVisualization(
+                                visualization,
+                                visualizationList
+                            )
+                        }}
+                        disabled={disabled}
+                    >
+                        {i18n.t('Delete')}
+                    </Button>
+                </div>
+            </div>
+        ))}
+    </>
+)
+
+VisualizationRow.propTypes = {
+    visualizations: PropTypes.array,
+    deleteVisualization: PropTypes.func,
+    disabled: PropTypes.bool,
+}

--- a/src/components/analyticVisualization/VisualizationTable/VisualizationTable.js
+++ b/src/components/analyticVisualization/VisualizationTable/VisualizationTable.js
@@ -1,0 +1,60 @@
+import React, { useState } from 'react'
+import PropTypes from '@dhis2/prop-types'
+import {
+    DataTable,
+    DataTableBody,
+    DataTableRow,
+    DataTableCell,
+} from '@dhis2/ui'
+import { GroupVisualizationRow } from './GroupVisualizationRow'
+import styles from './VisualizationTable.module.css'
+
+export const VisualizationTable = ({
+    rows,
+    deleteVisualization,
+    deleteGroup,
+    element,
+    disabled,
+}) => {
+    const [openRowIndex, setOpenRowIndex] = useState(null)
+
+    const toggleOpenRow = index =>
+        setOpenRowIndex(openRowIndex === index ? null : index)
+
+    const expandableContent = item => (
+        <GroupVisualizationRow
+            group={item}
+            deleteVisualization={deleteVisualization}
+            deleteGroup={deleteGroup}
+            element={element}
+            disabled={disabled}
+        />
+    )
+
+    return (
+        <DataTable>
+            <DataTableBody>
+                {Object.keys(rows).map((item, i) => (
+                    <DataTableRow
+                        expanded={openRowIndex === i}
+                        onExpandToggle={() => toggleOpenRow(i)}
+                        expandableContent={expandableContent(rows[item])}
+                        key={item}
+                    >
+                        <DataTableCell className={styles.tableTitle}>
+                            {rows[item][`${element}Name`]}
+                        </DataTableCell>
+                    </DataTableRow>
+                ))}
+            </DataTableBody>
+        </DataTable>
+    )
+}
+
+VisualizationTable.propTypes = {
+    rows: PropTypes.object,
+    element: PropTypes.string,
+    deleteVisualization: PropTypes.func,
+    deleteGroup: PropTypes.func,
+    disabled: PropTypes.bool,
+}

--- a/src/components/analyticVisualization/VisualizationTable/VisualizationTable.module.css
+++ b/src/components/analyticVisualization/VisualizationTable/VisualizationTable.module.css
@@ -1,0 +1,36 @@
+.rowContainer {
+    display: flex;
+    margin: 8px 8px 8px 40px;
+    padding: 0 12px;
+    border: 1px solid rgb(232, 237, 242);
+}
+
+.table {
+    border-bottom-color: #ffffff !important;
+}
+
+.rowPadding {
+    margin: 0 -12px;
+}
+
+.tableTitle {
+    font-weight: 500;
+}
+
+.tableSubtitle {
+    color: var(--colors-grey800)!important;
+    font-weight: 500;
+}
+
+.boxContainer {
+    display: grid;
+    grid-template-columns: 3fr 1fr;
+}
+
+.table > tbody > tr > td:first-child {
+    padding-left: 40px;
+}
+
+.boxContainer > div {
+    align-self: center
+}

--- a/src/components/analyticVisualization/VisualizationTable/helper.js
+++ b/src/components/analyticVisualization/VisualizationTable/helper.js
@@ -1,0 +1,37 @@
+import findIndex from 'lodash/findIndex'
+import isEmpty from 'lodash/isEmpty'
+import omit from 'lodash/omit'
+
+export const removeElement = (elementList, elementId) =>
+    omit(elementList, [elementId])
+
+export const updateElement = (elementList, elementId, updatedElement) =>
+    Object.assign({}, elementList, {
+        [elementId]: updatedElement,
+    })
+
+export const updateGroup = (elementList, elementId, updatedElement) =>
+    !isEmpty(updatedElement)
+        ? updateElement(elementList, elementId, updatedElement)
+        : removeElement(elementList, elementId)
+
+const updateList = (groups, groupId, updatedList) => {
+    const groupFound = groups.find(group => group.id === groupId)
+    const index = findIndex(groups, { id: groupId })
+    const updatedGroup = groups.slice()
+    updatedGroup.splice(
+        index,
+        1,
+        updateElement(groupFound, 'visualizations', updatedList)
+    )
+
+    return updatedGroup
+}
+
+export const removeElementList = (groups, groupId) =>
+    groups.filter(group => group.id !== groupId)
+
+export const updateGroupList = (groups, groupId, updatedElement) =>
+    !isEmpty(updatedElement)
+        ? updateList(groups, groupId, updatedElement)
+        : removeElementList(groups, groupId)

--- a/src/components/analyticVisualization/index.js
+++ b/src/components/analyticVisualization/index.js
@@ -1,0 +1,1 @@
+export * from './VisualizationTable/ProgramTable'

--- a/src/components/dialog/DialogDeleteElement.js
+++ b/src/components/dialog/DialogDeleteElement.js
@@ -1,0 +1,50 @@
+import React from 'react'
+import i18n from '@dhis2/d2-i18n'
+import PropTypes from '@dhis2/prop-types'
+import {
+    Modal,
+    ModalTitle,
+    ModalContent,
+    ModalActions,
+    ButtonStrip,
+    Button,
+} from '@dhis2/ui'
+
+const DialogDeleteElement = ({
+    open,
+    onHandleClose,
+    text,
+    element,
+    onHandleDelete,
+}) => (
+    <>
+        {open && (
+            <Modal small position="middle" onClose={onHandleClose}>
+                <ModalTitle>
+                    {i18n.t('Delete {{element}}', { element })}
+                </ModalTitle>
+                <ModalContent>{text}</ModalContent>
+                <ModalActions>
+                    <ButtonStrip end>
+                        <Button onClick={onHandleClose}>
+                            {i18n.t('Cancel')}
+                        </Button>
+                        <Button onClick={onHandleDelete} destructive>
+                            {i18n.t('Delete')}
+                        </Button>
+                    </ButtonStrip>
+                </ModalActions>
+            </Modal>
+        )}
+    </>
+)
+
+DialogDeleteElement.propTypes = {
+    open: PropTypes.bool,
+    onHandleClose: PropTypes.func,
+    onHandleDelete: PropTypes.func,
+    text: PropTypes.string,
+    element: PropTypes.string,
+}
+
+export default DialogDeleteElement

--- a/src/pages/Analytics/Program/ProgramAnalytics.js
+++ b/src/pages/Analytics/Program/ProgramAnalytics.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react'
 import i18n from '@dhis2/d2-i18n'
 import { useDataMutation, useDataQuery } from '@dhis2/app-runtime'
 import isEmpty from 'lodash/isEmpty'
+import isEqual from 'lodash/isEqual'
 import Page from '../../../components/page/Page'
 import {
     saveAnalyticsKeyMutation,
@@ -11,6 +12,7 @@ import { authorityQuery } from '../../../modules/apiLoadFirstSetup'
 import FooterStripButtons from '../../../components/footerStripButton/FooterStripButtons'
 import ProgramAnalyticsList from './ProgramAnalyticsList'
 import { VisualizationsInfo } from '../../../components/noticeAlert'
+import { createDataStoreGroupRows } from './helper'
 
 const ProgramAnalytics = () => {
     const {
@@ -23,6 +25,7 @@ const ProgramAnalytics = () => {
     } = useReadAnalyticsDataStore()
     const { data: hasAuthority } = useDataQuery(authorityQuery)
     const [programsAnalytics, setProgramAnalytics] = useState()
+    const [initialValues, setInitialValues] = useState()
     const [disableSave, setDisableSave] = useState(true)
     const [disable, setDisable] = useState(false)
 
@@ -35,15 +38,24 @@ const ProgramAnalytics = () => {
     useEffect(() => {
         if (program) {
             setProgramAnalytics(program)
+            setInitialValues(program)
         }
     }, [program])
+
+    useEffect(() => {
+        initialValues &&
+        programsAnalytics &&
+        !isEqual(programsAnalytics, initialValues)
+            ? setDisableSave(false)
+            : setDisableSave(true)
+    }, [programsAnalytics])
 
     const saveSettings = async () => {
         const settingsToSave = {
             tei,
             dhisVisualizations: {
                 home,
-                program: {},
+                program: createDataStoreGroupRows(programsAnalytics),
                 dataSet,
             },
         }
@@ -72,7 +84,11 @@ const ProgramAnalytics = () => {
                         />
                     )}
 
-                    <ProgramAnalyticsList disable={disable} />
+                    <ProgramAnalyticsList
+                        disable={disable}
+                        visualizations={programsAnalytics}
+                        handleVisualizations={setProgramAnalytics}
+                    />
 
                     <FooterStripButtons
                         onSave={saveSettings}

--- a/src/pages/Analytics/Program/ProgramAnalyticsList.js
+++ b/src/pages/Analytics/Program/ProgramAnalyticsList.js
@@ -1,16 +1,61 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
+import PropTypes from '@dhis2/prop-types'
 import i18n from '@dhis2/d2-i18n'
+import isEmpty from 'lodash/isEmpty'
+import isEqual from 'lodash/isEqual'
+import { ProgramTable } from '../../../components/analyticVisualization'
+import { useReadProgramQuery } from './ProgramVisualizationQueries'
+import { prepareRows, rowsToDataStore } from './helper'
 import { AddNewSetting } from '../../../components/field'
 
-const ProgramAnalyticsList = ({ disable }) => {
+const ProgramAnalyticsList = ({
+    visualizations,
+    handleVisualizations,
+    disable,
+}) => {
+    const { programList } = useReadProgramQuery()
+    const [rows, setRows] = useState()
+    const [initialRows, setInitialRows] = useState()
+
+    useEffect(() => {
+        if (visualizations && programList) {
+            const { visualizationsByPrograms } = prepareRows(
+                visualizations,
+                programList
+            )
+            setRows(visualizationsByPrograms)
+            setInitialRows(visualizationsByPrograms)
+        }
+    }, [visualizations, programList])
+
+    useEffect(() => {
+        if (rows && initialRows && !isEqual(rows, initialRows)) {
+            handleVisualizations(rowsToDataStore(rows))
+        }
+    }, [rows])
+
     return (
         <>
+            {!isEmpty(rows) && (
+                <ProgramTable
+                    rows={rows}
+                    changeRows={setRows}
+                    disabled={disable}
+                />
+            )}
+
             <AddNewSetting
                 label={i18n.t('Add Program Visualization')}
                 disable={disable}
             />
         </>
     )
+}
+
+ProgramAnalyticsList.propTypes = {
+    visualizations: PropTypes.object,
+    handleVisualizations: PropTypes.func,
+    disable: PropTypes.bool,
 }
 
 export default ProgramAnalyticsList

--- a/src/pages/Analytics/Program/ProgramVisualizationQueries.js
+++ b/src/pages/Analytics/Program/ProgramVisualizationQueries.js
@@ -1,0 +1,21 @@
+import { useDataQuery } from '@dhis2/app-runtime'
+
+const programsQuery = {
+    programs: {
+        resource: 'programs',
+        params: {
+            fields: ['id', 'name'],
+            pager: false,
+        },
+    },
+}
+
+export const useReadProgramQuery = () => {
+    const { loading, data, error } = useDataQuery(programsQuery)
+
+    return {
+        loading,
+        error,
+        programList: data && data.programs.programs,
+    }
+}

--- a/src/pages/Analytics/Program/helper.js
+++ b/src/pages/Analytics/Program/helper.js
@@ -1,0 +1,99 @@
+import mapValues from 'lodash/mapValues'
+
+export const getGroupList = visualizations => {
+    const groupList = {}
+
+    mapValues(visualizations, (program, i) => {
+        const programGroup = []
+        mapValues(program.groups, group => {
+            programGroup.push({
+                id: group[0].group.id,
+                name: group[0].group.name,
+                program: i,
+                programName: program.programName,
+            })
+            groupList[i] = programGroup
+        })
+    })
+
+    return groupList
+}
+
+export const prepareRows = (visualizations, programList) => {
+    const rows = {}
+    mapValues(visualizations, (program, i) => {
+        let groups = {}
+        program.map(group => {
+            const visual = []
+            const foundProgram = programList.find(p => p.id === i)
+            group.program = i
+            group.programName = program.programName || foundProgram.name
+            group.visualizations.map(visualization => {
+                visual.push({
+                    ...visualization,
+                    timestamp: visualization.timestamp || new Date().toJSON(),
+                    program: i,
+                    programName: program.programName || foundProgram.name,
+                    group: {
+                        id: group.id,
+                        name: group.name,
+                    },
+                })
+                groups = {
+                    ...groups,
+                    [group.id]: visual,
+                }
+                rows[i] = {
+                    programName: program.programName || foundProgram.name,
+                    groups: { ...groups },
+                }
+            })
+        })
+    })
+
+    return {
+        visualizationsByPrograms: rows,
+        groupList: getGroupList(rows),
+    }
+}
+
+export const createGroup = (group, visualizations) => ({
+    id: group.id,
+    name: group.name,
+    visualizations: group.visualizations || visualizations,
+})
+
+export const rowsToDataStore = rows => {
+    const updatedRows = {}
+
+    mapValues(rows, (program, i) => {
+        const groups = []
+        mapValues(program.groups, group => {
+            const visualizations = []
+            let groupUpdated = {}
+            group.map(visualization => {
+                visualizations.push({
+                    id: visualization.id,
+                    name: visualization.name,
+                    timestamp: visualization.timestamp,
+                })
+                groupUpdated = createGroup(visualization.group, visualizations)
+            })
+            groups.push(groupUpdated)
+            updatedRows[i] = groups
+        })
+    })
+    return updatedRows
+}
+
+export const createDataStoreGroupRows = datastore => {
+    const dataStoreGroups = Object.assign({}, datastore)
+    const result = {}
+    mapValues(dataStoreGroups, (program, i) => {
+        const groups = []
+        program.map(group => groups.push(createGroup(group)))
+        result[i] = groups
+    })
+
+    return result
+}


### PR DESCRIPTION
The current PR has:

- Show Program visualization separated by program and group.
- Delete a visualization group
- Delete a visualization
- Update datastore

_Visualization table by programs_
![image](https://user-images.githubusercontent.com/29384664/141063377-4343e8d1-81be-4ea0-aa98-f9a0bf9a76e9.png)

_Visualization by groups_
![image](https://user-images.githubusercontent.com/29384664/141063423-0dc5d93a-77e3-4044-b93f-f0297867742d.png)

_Visualizations_
![image](https://user-images.githubusercontent.com/29384664/141063467-c7c09afd-6817-48ec-a20c-c92b936013e4.png)
