### PR TITLE
feat: add Data set visualization and groups

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-11-15T17:50:59.768Z\n"
-"PO-Revision-Date: 2021-11-15T17:50:59.768Z\n"
+"POT-Creation-Date: 2021-11-16T01:39:38.876Z\n"
+"PO-Revision-Date: 2021-11-16T01:39:38.876Z\n"
 
 msgid "Edit"
 msgstr ""
@@ -23,6 +23,9 @@ msgid "Failed to get data from Data Store"
 msgstr ""
 
 msgid "Settings were successfully saved"
+msgstr ""
+
+msgid "Dataset"
 msgstr ""
 
 msgid "Program"
@@ -594,13 +597,16 @@ msgstr ""
 msgid "data download size (KB)"
 msgstr ""
 
-msgid "Add Data set Visualization"
-msgstr ""
-
 msgid "Manage visualizations for data set."
 msgstr ""
 
 msgid "Could not find any data set visualisations"
+msgstr ""
+
+msgid "Add Data set visualization"
+msgstr ""
+
+msgid "Add Data set Visualization"
 msgstr ""
 
 msgid "Add Home Visualization"

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-11-15T23:27:02.773Z\n"
-"PO-Revision-Date: 2021-11-15T23:27:02.773Z\n"
+"POT-Creation-Date: 2021-11-16T14:37:03.167Z\n"
+"PO-Revision-Date: 2021-11-16T14:37:03.167Z\n"
 
 msgid "Edit"
 msgstr ""
@@ -23,6 +23,9 @@ msgid "Failed to get data from Data Store"
 msgstr ""
 
 msgid "Settings were successfully saved"
+msgstr ""
+
+msgid "Dataset"
 msgstr ""
 
 msgid "Program"
@@ -594,13 +597,16 @@ msgstr ""
 msgid "data download size (KB)"
 msgstr ""
 
-msgid "Add Data set Visualization"
-msgstr ""
-
 msgid "Manage visualizations for data set."
 msgstr ""
 
 msgid "Could not find any data set visualisations"
+msgstr ""
+
+msgid "Add Data set visualization"
+msgstr ""
+
+msgid "Add Data set Visualization"
 msgstr ""
 
 msgid "Add Home visualization"

--- a/src/components/analyticVisualization/SelectDataset.js
+++ b/src/components/analyticVisualization/SelectDataset.js
@@ -1,0 +1,37 @@
+import React from 'react'
+import i18n from '@dhis2/d2-i18n'
+import PropTypes from '@dhis2/prop-types'
+import { SelectField } from '../field'
+import { useReadDatasetQuery } from '../../pages/Analytics/Dataset/DatasetVisualizationQuery'
+
+export const SelectDataset = ({ settings, onChange }) => {
+    const { datasetList, loading } = useReadDatasetQuery()
+    const options = datasetList || []
+
+    const handleChange = e => {
+        const name = options.find(dataset => dataset.id === e.selected)
+        onChange({
+            ...settings,
+            dataset: e.selected,
+            datasetName: name.name,
+        })
+    }
+
+    return (
+        <SelectField
+            dense
+            inputWidth="350px"
+            name="dataset"
+            label={i18n.t('Dataset')}
+            selected={settings.dataset || ''}
+            onChange={handleChange}
+            options={options}
+            loading={loading}
+        />
+    )
+}
+
+SelectDataset.propTypes = {
+    settings: PropTypes.object,
+    onChange: PropTypes.func,
+}

--- a/src/components/analyticVisualization/index.js
+++ b/src/components/analyticVisualization/index.js
@@ -1,3 +1,4 @@
+export * from './SelectDataset'
 export * from './SelectProgram'
 export * from './SelectVisualization'
 export * from './VisualizationGroup/VisualizationGroup'

--- a/src/pages/Analytics/Dataset/DatasetAnalyticList.js
+++ b/src/pages/Analytics/Dataset/DatasetAnalyticList.js
@@ -1,12 +1,11 @@
 import React, { useEffect, useState } from 'react'
 import PropTypes from '@dhis2/prop-types'
-import i18n from '@dhis2/d2-i18n'
 import isEmpty from 'lodash/isEmpty'
 import isEqual from 'lodash/isEqual'
 import { useReadDatasetQuery } from './DatasetVisualizationQuery'
 import { prepareRows, rowsToDataStore } from './helper'
+import NewDatasetVisualization from './NewDatasetVisualization'
 import { DatasetTable } from '../../../components/analyticVisualization'
-import { AddNewSetting } from '../../../components/field'
 
 const DatasetAnalyticList = ({
     visualizations,
@@ -16,14 +15,16 @@ const DatasetAnalyticList = ({
     const { datasetList } = useReadDatasetQuery()
     const [rows, setRows] = useState()
     const [initialRows, setInitialRows] = useState()
+    const [groups, setGroups] = useState()
 
     useEffect(() => {
         if (visualizations && datasetList) {
-            const { visualizationsByDatasets } = prepareRows(
+            const { visualizationsByDatasets, groupList } = prepareRows(
                 visualizations,
                 datasetList
             )
             setRows(visualizationsByDatasets)
+            setGroups(groupList)
             setInitialRows(visualizationsByDatasets)
         }
     }, [visualizations, datasetList])
@@ -44,9 +45,12 @@ const DatasetAnalyticList = ({
                 />
             )}
 
-            <AddNewSetting
-                label={i18n.t('Add Data set Visualization')}
+            <NewDatasetVisualization
                 disable={disable}
+                visualization={rows}
+                handleVisualization={setRows}
+                groups={groups}
+                handleGroups={setGroups}
             />
         </>
     )

--- a/src/pages/Analytics/Dataset/DialogVisualization.js
+++ b/src/pages/Analytics/Dataset/DialogVisualization.js
@@ -1,0 +1,90 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import {
+    Modal,
+    ModalTitle,
+    ModalContent,
+    ModalActions,
+    ButtonStrip,
+    Button,
+} from '@dhis2/ui'
+import i18n from '@dhis2/d2-i18n'
+import buttonStyles from '../../../styles/Button.module.css'
+import {
+    VisualizationGroup,
+    SelectDataset,
+    SelectVisualization,
+    VisualizationTitle,
+} from '../../../components/analyticVisualization'
+
+const DialogVisualization = ({
+    open,
+    settings,
+    handleChange,
+    disableSave,
+    handleClose,
+    handleSave,
+    groups,
+}) => (
+    <>
+        {open && (
+            <Modal large position="middle">
+                <ModalTitle>{i18n.t('Add Data set visualization')}</ModalTitle>
+
+                <ModalContent>
+                    <SelectDataset
+                        settings={settings}
+                        onChange={handleChange}
+                    />
+
+                    <SelectVisualization
+                        settings={settings}
+                        onChange={handleChange}
+                    />
+
+                    {settings.visualization && (
+                        <>
+                            <VisualizationTitle
+                                settings={settings}
+                                onChange={handleChange}
+                            />
+
+                            <VisualizationGroup
+                                settings={settings}
+                                onChange={handleChange}
+                                groupList={groups}
+                                type="dataset"
+                            />
+                        </>
+                    )}
+                </ModalContent>
+
+                <ModalActions>
+                    <ButtonStrip end>
+                        <Button
+                            onClick={handleClose}
+                            className={buttonStyles.mainContent__dialog__button}
+                        >
+                            {i18n.t('Cancel')}
+                        </Button>
+                        <Button onClick={handleSave} disabled={disableSave}>
+                            {i18n.t('Add Data set Visualization')}
+                        </Button>
+                    </ButtonStrip>
+                </ModalActions>
+            </Modal>
+        )}
+    </>
+)
+
+DialogVisualization.propTypes = {
+    open: PropTypes.bool,
+    settings: PropTypes.object,
+    handleChange: PropTypes.func,
+    disableSave: PropTypes.bool,
+    handleClose: PropTypes.func,
+    handleSave: PropTypes.func,
+    groups: PropTypes.object,
+}
+
+export default DialogVisualization

--- a/src/pages/Analytics/Dataset/NewDatasetVisualization.js
+++ b/src/pages/Analytics/Dataset/NewDatasetVisualization.js
@@ -1,0 +1,84 @@
+import React, { useEffect, useState } from 'react'
+import i18n from '@dhis2/d2-i18n'
+import PropTypes from '@dhis2/prop-types'
+import { AddNewSetting } from '../../../components/field'
+import {
+    createInitialValues,
+    createVisualizationValues,
+    getGroupList,
+    invalidMandatoryFields,
+    updateRows,
+} from './helper'
+import DialogVisualization from './DialogVisualization'
+
+const NewDatasetVisualization = ({
+    disable,
+    visualization,
+    handleVisualization,
+    groups,
+    handleGroups,
+}) => {
+    const [openDialog, setOpenDialog] = useState(false)
+    const [visualizationSettings, setSettings] = useState(
+        createInitialValues('')
+    )
+    const [disableSave, setDisableSave] = useState(true)
+
+    useEffect(() => {
+        setDisableSave(invalidMandatoryFields(visualizationSettings))
+    }, [visualizationSettings])
+
+    const handleOpenDialog = () => {
+        setOpenDialog(true)
+    }
+
+    const handleClose = () => {
+        setOpenDialog(false)
+        setSettings(createInitialValues(''))
+    }
+
+    const handleSave = () => {
+        const currentVisualization = createVisualizationValues(
+            visualizationSettings
+        )
+        const updatedVisualizationList = updateRows(
+            currentVisualization,
+            visualization
+        )
+        handleVisualization(updatedVisualizationList)
+        handleGroups(getGroupList(updatedVisualizationList))
+        handleClose()
+    }
+
+    return (
+        <>
+            <AddNewSetting
+                label={i18n.t('Add Data set Visualization')}
+                onClick={handleOpenDialog}
+                disable={disable}
+            />
+
+            {openDialog && (
+                <DialogVisualization
+                    open={openDialog}
+                    settings={visualizationSettings}
+                    handleChange={setSettings}
+                    handleSave={handleSave}
+                    handleClose={handleClose}
+                    disableSave={disableSave}
+                    groups={groups}
+                />
+            )}
+        </>
+    )
+}
+
+NewDatasetVisualization.propTypes = {
+    disable: PropTypes.bool,
+    visualization: PropTypes.object,
+    handleVisualization: PropTypes.func,
+    groups: PropTypes.object,
+    handleGroups: PropTypes.func,
+}
+
+export default NewDatasetVisualization

--- a/src/pages/Analytics/Dataset/helper.js
+++ b/src/pages/Analytics/Dataset/helper.js
@@ -1,4 +1,61 @@
 import mapValues from 'lodash/mapValues'
+import { validateObjectByProperty } from '../../../utils/validators'
+
+export const createInitialValues = initialValues => ({
+    id: initialValues.id || '',
+    dataset: initialValues.dataset || '',
+    visualization: initialValues.visualization || '',
+    name: initialValues.name || '',
+    group: initialValues.group || {
+        name: '',
+        id: '',
+    },
+})
+
+export const invalidMandatoryFields = settings => {
+    return !validateObjectByProperty(['dataset', 'visualization'], settings)
+}
+
+export const createVisualizationValues = value => ({
+    id: value.visualization || value.id,
+    name: value.name || value.visualizationName,
+    timestamp: value.timestamp || new Date().toJSON(),
+    dataset: value.dataset,
+    datasetName: value.datasetName,
+    group: {
+        id: value.group.id,
+        name: value.group.name,
+    },
+})
+
+export const updateRows = (current, rows) => {
+    const datasetRow = rows[current.dataset]
+
+    if (datasetRow) {
+        const group = datasetRow.groups[current.group.id]
+        const updatedGroups = {
+            ...datasetRow.groups,
+            [current.group.id]: group ? [...group, current] : [current],
+        }
+        return {
+            ...rows,
+            [current.dataset]: {
+                ...datasetRow,
+                groups: updatedGroups,
+            },
+        }
+    }
+
+    return {
+        ...rows,
+        [current.dataset]: {
+            datasetName: current.datasetName,
+            groups: {
+                [current.group.id]: [current],
+            },
+        },
+    }
+}
 
 export const getGroupList = visualizations => {
     const groupList = {}


### PR DESCRIPTION
This PR has:

- Dialog to add home visualizations:
  - Search visualization
  - Add title
  - Select group



![image](https://user-images.githubusercontent.com/29384664/141881987-47120e27-2f65-4e8b-a64c-f27a4cf5ebba.png)

![image](https://user-images.githubusercontent.com/29384664/141882052-583aa510-2c65-4965-8dc0-f29e46a9988b.png)
