### PR TITLE
fix: [DHIS2-12253] [synchronization] change filter data to metadata program dataset

### DIFF
--- a/src/pages/Synchronization/Datasets/datasetQueries.js
+++ b/src/pages/Synchronization/Datasets/datasetQueries.js
@@ -9,7 +9,7 @@ export const getDatasetQuery = {
         resource: 'dataSets',
         params: {
             fields: ['id', 'name', 'periodType'],
-            filter: 'access.data.write:eq:true',
+            filter: 'access.read:eq:true',
             pager: false,
         },
     },

--- a/src/pages/Synchronization/Programs/programQueries.js
+++ b/src/pages/Synchronization/Programs/programQueries.js
@@ -8,7 +8,7 @@ export const getProgramsQuery = {
         resource: 'programs',
         params: {
             fields: ['id', 'name', 'programType'],
-            filter: 'access.data.write:eq:true',
+            filter: 'access.read:eq:true',
         },
     },
 }


### PR DESCRIPTION
Change Program and Data set sync settings API call.

From: `filter: 'access.data.write:eq:true'`

To: `filter: 'access.read:eq:true'`
