### PR TITLE
fix: checkbox remains unchecked

### DIFF
--- a/src/components/field/TrackerImporter.js
+++ b/src/components/field/TrackerImporter.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import i18n from '@dhis2/d2-i18n'
-import PropTypes from '@dhis2/prop-types'
+import PropTypes from 'prop-types'
 import { CheckboxField } from './CheckboxField'
 import { useApiVersion } from '../../utils/useApiVersion'
 
@@ -14,7 +14,7 @@ const isValidVersion = apiVersion => apiVersion >= minApiVersion
 
 export const TrackerImporter = ({ value, onChange, ...props }) => {
     const [validVersion, setValidVersion] = useState(false)
-    const [tracker, setTracker] = useState(false)
+    const [tracker, setTracker] = useState(value[CODE] === newTrackerVersion)
     const { apiVersion } = useApiVersion()
 
     useEffect(() => {

--- a/src/pages/Synchronization/Global/GlobalSettings.js
+++ b/src/pages/Synchronization/Global/GlobalSettings.js
@@ -56,7 +56,11 @@ const GlobalSettings = () => {
     }, [settings])
 
     const saveSettings = async () => {
-        const settingsToSave = { ...settings, dataSetSettings, programSettings }
+        const settingsToSave = {
+            ...createInitialValues(settings),
+            dataSetSettings,
+            programSettings,
+        }
         await mutate({ settings: settingsToSave })
     }
 

--- a/src/pages/Synchronization/Global/helper.js
+++ b/src/pages/Synchronization/Global/helper.js
@@ -1,7 +1,13 @@
-import { defaultDataSync, defaultMetadataSync } from '../../../components/field'
+import {
+    defaultDataSync,
+    defaultMetadataSync,
+    defaultTrackerImporterVersion,
+} from '../../../components/field'
 
 export const createInitialValues = prevGlobalDetails => ({
     metadataSync: prevGlobalDetails.metadataSync || defaultMetadataSync,
     dataSync: prevGlobalDetails.dataSync || defaultDataSync,
-    newTrackerImporter: false,
+    trackerImporterVersion:
+        prevGlobalDetails.trackerImporterVersion ||
+        defaultTrackerImporterVersion,
 })


### PR DESCRIPTION
This PR has:

Previous scenario:
Synchronization Global: After changing to other sections, the Tracker Importer checkbox remains unchecked even if it was checked and saved before.

Solution: Checked the tracker importer version before rendering the components
V1 = default version
V2 = new tracker importer


![image](https://user-images.githubusercontent.com/29384664/151477397-8e14f803-25ec-4e14-881f-1fdec80bd829.png)

_Datastore_
![image](https://user-images.githubusercontent.com/29384664/151477447-351fe6b6-3da7-4211-8db7-8fe9e3fc5273.png)
