### PR TITLE
fix: verify new visualization group and format datastore

### DIFF
--- a/src/pages/Analytics/Home/HomeAnalyticList.js
+++ b/src/pages/Analytics/Home/HomeAnalyticList.js
@@ -21,16 +21,22 @@ const HomeAnalyticList = ({
         visualizations: visualizationAPI,
     } = useVisualizations(getVisualizationIdList(visualizations))
     const [rows, setRows] = useState([])
+    const [initialRows, setInitialRows] = useState([])
 
     useEffect(() => {
         if (!isEmpty(visualizations) && visualizationAPI) {
-            setRows(createRows(visualizations, visualizationAPI))
+            const homeVisualizations = createRows(
+                visualizations,
+                visualizationAPI
+            )
+            setRows(homeVisualizations)
+            setInitialRows(homeVisualizations)
         }
     }, [visualizations, visualizationAPI])
 
     useEffect(() => {
-        if (rows && visualizations && !isEqual(rows, visualizations)) {
-            handleVisualizations(rows)
+        if (rows && initialRows && !isEqual(rows, initialRows)) {
+            handleVisualizations(createRows(rows))
         }
     }, [rows])
 

--- a/src/pages/Analytics/Home/HomeAnalytics.js
+++ b/src/pages/Analytics/Home/HomeAnalytics.js
@@ -12,7 +12,6 @@ import {
     useReadAnalyticsDataStore,
 } from '../analyticsDatastoreQuery'
 import { authorityQuery } from '../../../modules/apiLoadFirstSetup'
-import { createRows } from './helper'
 
 const HomeAnalytics = () => {
     const {
@@ -50,7 +49,7 @@ const HomeAnalytics = () => {
         const settingsToSave = {
             tei,
             dhisVisualizations: {
-                home: createRows(homeAnalytics),
+                home: homeAnalytics,
                 program,
                 dataSet,
             },


### PR DESCRIPTION
This PR seeks to correct the following:
when new visualizations were added, they were not saved in the correct format, which caused errors when displaying the table and lost information.
 
Fixed by checking the difference between the list of initial visualizations and the list of recently added views each time a change is made.

_Data wrongly saved an empty visualization group_
![image](https://user-images.githubusercontent.com/29384664/152653304-06d86d64-6379-4ace-b213-b5e17633e91a.png)


_Data saved after fixing bug_
![image](https://user-images.githubusercontent.com/29384664/152653103-1cf6ba73-0c44-4600-a0a5-4aa1cc13b8fa.png)
