### PR TITLE
fix: change datastore key appearance

### DIFF
--- a/src/constants/appearance-settings.js
+++ b/src/constants/appearance-settings.js
@@ -1,5 +1,5 @@
 export const appearanceDefault = {
-    completionSpinner: {
+    programConfiguration: {
         globalSettings: {
             visible: true,
         },


### PR DESCRIPTION
This PR changes the appearance key to the new format:

```
"programConfiguration": {
     "globalSettings": {
        "completionSpinner": true
     },
    "specificSettings": {
        "programUID": {
            "completionSpinner": false,
            "optionalSearchl": true
        }
    }
}
```
