### PR TITLE
fix: appearance add completion spinner key to datastore json

### DIFF
--- a/src/components/field/OptionalTEISearch.js
+++ b/src/components/field/OptionalTEISearch.js
@@ -15,7 +15,7 @@ export const OptionalTEISearch = ({
             <CheckboxField
                 name={CODE}
                 label={i18n.t(
-                    'Allow the user to create a TEI without the prior search'
+                    'Allow the user to create a TEI without searching'
                 )}
                 onChange={handleChange}
                 checked={settings[CODE]}

--- a/src/constants/appearance-settings.js
+++ b/src/constants/appearance-settings.js
@@ -5,6 +5,12 @@ export const appearanceDefault = {
         },
         specificSettings: {},
     },
+    completionSpinner: {
+        globalSettings: {
+            visible: true,
+        },
+        specificSettings: {},
+    },
     filterSorting: {
         home: {
             assignedToMe: {

--- a/src/pages/Appearance/Datasets/DatasetsAppearance.js
+++ b/src/pages/Appearance/Datasets/DatasetsAppearance.js
@@ -19,6 +19,7 @@ const DatasetsAppearance = () => {
         load,
         dataSetSettings,
         programConfiguration,
+        completionSpinner,
         home,
         programSettings,
     } = useReadAppearanceDataStore()
@@ -63,6 +64,7 @@ const DatasetsAppearance = () => {
     const saveSettings = async () => {
         const settingsToSave = {
             programConfiguration,
+            completionSpinner,
             filterSorting: {
                 home,
                 programSettings,

--- a/src/pages/Appearance/Home/HomeAppearance.js
+++ b/src/pages/Appearance/Home/HomeAppearance.js
@@ -17,6 +17,7 @@ const HomeAppearance = () => {
         load,
         home,
         programConfiguration,
+        completionSpinner,
         programSettings,
         dataSetSettings,
     } = useReadAppearanceDataStore()
@@ -50,6 +51,7 @@ const HomeAppearance = () => {
     const saveSettings = async () => {
         const settingsToSave = {
             programConfiguration,
+            completionSpinner,
             filterSorting: {
                 home: settings,
                 programSettings,

--- a/src/pages/Appearance/Programs/ProgramsAppearance.js
+++ b/src/pages/Appearance/Programs/ProgramsAppearance.js
@@ -8,6 +8,7 @@ import {
     useReadAppearanceDataStore,
 } from '../appearanceDatastoreQuery'
 import {
+    createInitialGlobalSpinner,
     createInitialSpinnerValue,
     createInitialValues,
     createSpecificValues,
@@ -55,7 +56,9 @@ const ProgramsAppearance = () => {
                   )
                 : setSpecificSettings({})
             setSpinnerSettings(programConfiguration)
-            setSpinnerGlobal(programConfiguration.globalSettings)
+            setSpinnerGlobal(
+                createInitialGlobalSpinner(programConfiguration.globalSettings)
+            )
             setSpinnerSpecific(programConfiguration.specificSettings)
         }
     }, [programSettings])

--- a/src/pages/Appearance/Programs/ProgramsAppearance.js
+++ b/src/pages/Appearance/Programs/ProgramsAppearance.js
@@ -9,15 +9,17 @@ import {
 } from '../appearanceDatastoreQuery'
 import {
     createInitialGlobalSpinner,
+    createInitialGlobalSpinnerPrevious,
     createInitialSpinnerValue,
     createInitialValues,
     createSpecificValues,
+    prepareSettingsSaveDataStore,
+    prepareSpinnerPreviousSpinner,
 } from './helper'
 import Page from '../../../components/page/Page'
 import ProgramGlobalSettings from './ProgramGlobalSettings'
 import FooterStripButtons from '../../../components/footerStripButton/FooterStripButtons'
 import ProgramSpecificSettings from './ProgramSpecificSettings'
-import { removeSummaryFromSettings } from '../../../utils/utils'
 
 const ProgramsAppearance = () => {
     const {
@@ -81,7 +83,15 @@ const ProgramsAppearance = () => {
                     ...spinnerGlobal,
                 },
                 specificSettings: {
-                    ...removeSummaryFromSettings(spinnerSpecific),
+                    ...prepareSettingsSaveDataStore(spinnerSpecific),
+                },
+            },
+            completionSpinner: {
+                globalSettings: {
+                    ...createInitialGlobalSpinnerPrevious(spinnerGlobal),
+                },
+                specificSettings: {
+                    ...prepareSpinnerPreviousSpinner(spinnerSpecific),
                 },
             },
             filterSorting: {
@@ -90,7 +100,7 @@ const ProgramsAppearance = () => {
                 programSettings: {
                     globalSettings,
                     specificSettings: {
-                        ...removeSummaryFromSettings(specificSettings),
+                        ...prepareSettingsSaveDataStore(specificSettings),
                     },
                 },
             },

--- a/src/pages/Appearance/Programs/helper.js
+++ b/src/pages/Appearance/Programs/helper.js
@@ -46,6 +46,13 @@ export const createInitialSpecificValues = prevDetails => ({
     followUp: prevDetails.followUp || filterSortingDefault,
 })
 
+export const createInitialGlobalSpinner = prevDetails => {
+    defaults(prevDetails, {
+        completionSpinner: true,
+    })
+    return { completionSpinner: prevDetails.completionSpinner }
+}
+
 /**
  * Add Follow up default value
  * */

--- a/src/pages/Appearance/Programs/helper.js
+++ b/src/pages/Appearance/Programs/helper.js
@@ -3,7 +3,11 @@ import defaults from 'lodash/defaults'
 import map from 'lodash/map'
 import toArray from 'lodash/toArray'
 import mapValues from 'lodash/mapValues'
-import { formatList } from '../../../utils/utils'
+import {
+    formatList,
+    removePropertiesFromObject,
+    removeSummaryFromSettings,
+} from '../../../utils/utils'
 
 const filterSortingDefault = {
     filter: true,
@@ -52,6 +56,27 @@ export const createInitialGlobalSpinner = prevDetails => {
     })
     return { completionSpinner: prevDetails.completionSpinner }
 }
+
+export const createInitialGlobalSpinnerPrevious = prevDetails => {
+    defaults(prevDetails, {
+        completionSpinner: true,
+    })
+    return { visible: prevDetails.completionSpinner }
+}
+
+export const prepareSpinnerPreviousSpinner = settings => {
+    const spinnerSettings = mapValues(settings, element => ({
+        ...element,
+        visible: element.completionSpinner,
+    }))
+    return removePropertiesFromObject(
+        prepareSettingsSaveDataStore(spinnerSettings),
+        ['optionalSearch', 'completionSpinner']
+    )
+}
+
+export const prepareSettingsSaveDataStore = settings =>
+    removeSummaryFromSettings(settings)
 
 /**
  * Add Follow up default value

--- a/src/pages/Appearance/appearanceDatastoreQuery.js
+++ b/src/pages/Appearance/appearanceDatastoreQuery.js
@@ -40,8 +40,9 @@ export const useReadAppearanceDataStore = () => {
         error,
         programConfiguration:
             data &&
-            (data.appearanceSettings.completionSpinner ||
-                data.appearanceSettings.programConfiguration),
+            (data.appearanceSettings.programConfiguration ||
+                data.appearanceSettings.completionSpinner),
+        completionSpinner: data && data.appearanceSettings.completionSpinner,
         filterSorting: data && data.appearanceSettings.filterSorting,
         home: data && data.appearanceSettings.filterSorting.home,
         programSettings:


### PR DESCRIPTION
This PR fixes:

- the optional search checkbox label
- the appearance key (globalSettings), to support different android versions by reintroducing `completionSpinner` key to datastore query and initial values:

```
"completionSpinner": {
     "globalSettings": {
        "visible": true
     },
    "specificSettings": {
        "programUID": {
            "visible": false,
        }
    }
}
```
