### PR TITLE
fix: [general] update disable settings helptext

### DIFF
--- a/src/components/dialog/DialogDisableSettings.js
+++ b/src/components/dialog/DialogDisableSettings.js
@@ -19,7 +19,7 @@ const DialogDisableSettings = ({ openDialog, onClose, disableSettings }) => {
                     <ModalTitle>{i18n.t('Disable all settings')}</ModalTitle>
                     <ModalContent>
                         {i18n.t(
-                            'This action will disable and remove all General, Program and Data set settings. Are you sure you want to disable all settings?'
+                            'This action will disable and remove all General, Synchronization, Appearance and Analytics settings. Are you sure you want to disable all settings?'
                         )}
                     </ModalContent>
                     <ModalActions>

--- a/src/pages/General/DisableSettings.js
+++ b/src/pages/General/DisableSettings.js
@@ -38,7 +38,7 @@ const DisableSettings = ({ disabled }) => {
                 name="disableSettings"
                 label={i18n.t('Disable all settings')}
                 helpText={i18n.t(
-                    'This will disable and remove all General, Program and Data set settings.'
+                    'This will disable and remove all General, Synchronization, Appearance and Analytics settings.'
                 )}
                 onOpen={onClick}
                 disabled={disabled}


### PR DESCRIPTION
This PR updates the "Disable all settings" help and Modal text, including the current Android Settings Webapp sections.

_Disable all settings button and helpText_
![image](https://user-images.githubusercontent.com/29384664/164499954-3ffdfc97-2941-4fa5-b3b7-3c28c8f916c9.png)

_Modal_
![image](https://user-images.githubusercontent.com/29384664/164500154-e3568627-f501-42dc-b422-8cd4f7028712.png)
