### PR TITLE
fix: change fixed period labels

### DIFF
--- a/src/components/analytics/VisualizationElement.js
+++ b/src/components/analytics/VisualizationElement.js
@@ -25,10 +25,6 @@ const elementTypeOptions = [
 
 const periodType = [
     {
-        value: 'Monthly',
-        label: i18n.t('Monthly'),
-    },
-    {
         value: 'Daily',
         label: i18n.t('Daily'),
     },
@@ -37,12 +33,16 @@ const periodType = [
         label: i18n.t('Weekly'),
     },
     {
+        value: 'Monthly',
+        label: i18n.t('Monthly'),
+    },
+    {
         value: 'Quarterly',
         label: i18n.t('Quarterly'),
     },
     {
         value: 'SixMonthly',
-        label: i18n.t('SixMonthly'),
+        label: i18n.t('Six-monthly'),
     },
     {
         value: 'Yearly',

--- a/src/constants/data-set-settings.js
+++ b/src/constants/data-set-settings.js
@@ -25,74 +25,92 @@ export const periodTypeConstants = {
     Daily: {
         type: 'Daily',
         default: 59,
+        label: 'Daily',
     },
     Weekly: {
         type: 'Weekly',
         default: 12,
+        label: 'Weekly',
     },
     WeeklyWednesday: {
         type: 'WeeklyWednesday',
         default: 12,
+        label: 'Weekly (Start Wednesday)',
     },
     WeeklyThursday: {
         type: 'WeeklyThursday',
         default: 12,
+        label: 'Weekly (Start Thursday)',
     },
     WeeklySaturday: {
         type: 'WeeklySaturday',
         default: 12,
+        label: 'Weekly (Start Saturday)',
     },
     WeeklySunday: {
         type: 'WeeklySunday',
         default: 12,
+        label: 'Weekly (Start Sunday)',
     },
     BiWeekly: {
         type: 'BiWeekly',
         default: 12,
+        label: 'Bi-weekly',
     },
     Monthly: {
         type: 'Monthly',
         default: 11,
+        label: 'Monthly',
     },
     BiMonthly: {
         type: 'BiMonthly',
         default: 5,
+        label: 'Bi-monthly',
     },
     Quarterly: {
         type: 'Quarterly',
         default: 4,
+        label: 'Quarterly',
     },
     SixMonthly: {
         type: 'SixMonthly',
         default: 4,
+        label: 'Six-monthly',
     },
     SixMonthlyApril: {
         type: 'SixMonthlyApril',
         default: 4,
+        label: 'Six-monthly April',
     },
     SixMonthlyNov: {
         type: 'SixMonthlyNov',
         default: 4,
+        label: 'Six-monthly November',
     },
     Yearly: {
         type: 'Yearly',
         default: 4,
+        label: 'Yearly',
     },
     FinancialApril: {
         type: 'FinancialApril',
         default: 4,
+        label: 'Financial year (Start April)',
     },
     FinancialJuly: {
         type: 'FinancialJuly',
         default: 4,
+        label: 'Financial year (Start July)',
     },
     FinancialOct: {
         type: 'FinancialOct',
         default: 4,
+        label: 'Financial year (Start October)',
     },
     FinancialNov: {
         type: 'FinancialNov',
         default: 4,
+        label: 'Financial year (Start November)',
     },
 }
 

--- a/src/pages/Synchronization/Datasets/SpecificSettings.js
+++ b/src/pages/Synchronization/Datasets/SpecificSettings.js
@@ -6,7 +6,7 @@ import TableRow from '../../../components/settingsTable/TableRow'
 import Wrapper from '../../../components/Wrapper'
 import { InputNumber } from '../../../components/inputs'
 import { DataSpecificSetting } from '../../../constants/data-set-settings'
-import { getPeriodDefaultValueByType } from './helper'
+import { getPeriodDefaultValueByType, getPeriodLabel } from './helper'
 import tableTitleStyles from '../../../styles/TableTitle.module.css'
 
 const DataSetTableRow = ({
@@ -49,9 +49,11 @@ DataSetTableRow.propTypes = {
 
 const SpecificSettings = ({ periodType, specificSettings, onChange }) => {
     const [defaultValue, setDefaultValue] = useState()
+    const [periodLabel, setPeriodLabel] = useState()
 
     useEffect(() => {
         setDefaultValue(getPeriodDefaultValueByType(periodType))
+        setPeriodLabel(getPeriodLabel(periodType))
     }, [periodType])
 
     return (
@@ -61,7 +63,7 @@ const SpecificSettings = ({ periodType, specificSettings, onChange }) => {
                     <DataSetTableRow
                         key={row.option}
                         row={row}
-                        periodType={periodType}
+                        periodType={periodLabel}
                         defaultValue={defaultValue}
                         specificSettings={specificSettings}
                         onChange={onChange}

--- a/src/pages/Synchronization/Datasets/helper.js
+++ b/src/pages/Synchronization/Datasets/helper.js
@@ -25,9 +25,10 @@ export const prepareSpecificSettingsList = (
 
     for (const key in datasetSettings) {
         if (datasetId.includes(key)) {
-            const periodType =
+            const periodType = getPeriodLabel(
                 getPeriodType(key, apiDatasetList).name ||
-                getPeriodType(key, apiDatasetList)
+                    getPeriodType(key, apiDatasetList)
+            )
             const dataset = datasetSettings[key]
             const summarySettings = `${dataset.periodDSDownload} ${periodType} period`
 
@@ -54,3 +55,5 @@ export const findDatasetName = (datasetList, specificProgram) => {
 
 export const getPeriodDefaultValueByType = periodType =>
     periodTypeConstants[periodType].default
+
+export const getPeriodLabel = period => periodTypeConstants[period].label


### PR DESCRIPTION
This PR fixes the period labels in Data set Synchronization and TEI Analytics section.

_Data set synchronization_
![image](https://user-images.githubusercontent.com/29384664/165091561-63e12717-7ac5-42f9-bb59-51ae76f3571d.png)

![image](https://user-images.githubusercontent.com/29384664/165091635-5647d44b-7320-40fe-8380-ee272510f064.png)

_TEI Analytics periods_
![image](https://user-images.githubusercontent.com/29384664/165091754-c016eddf-0355-4b59-9d72-bed61899f845.png)
