### PR TITLE
feat: use new tracker importer as default [DHIS2-14741]

### DIFF
--- a/src/components/field/TrackerImporter.js
+++ b/src/components/field/TrackerImporter.js
@@ -6,11 +6,14 @@ import { CheckboxField } from './CheckboxField'
 
 const CODE = 'trackerImporterVersion'
 const minApiVersion = '2.38'
+const minApiVersionNewTrackerDefault = '2.40'
 
 export const defaultTrackerImporterVersion = 'V1'
 export const newTrackerVersion = 'V2'
 
 const isValidVersion = (apiVersion) => apiVersion >= minApiVersion
+const shouldUseNewTracker = (apiVersion) =>
+    apiVersion >= minApiVersionNewTrackerDefault
 
 export const TrackerImporter = ({ value, onChange, ...props }) => {
     const [validVersion, setValidVersion] = useState(false)
@@ -22,6 +25,14 @@ export const TrackerImporter = ({ value, onChange, ...props }) => {
             isValidVersion(apiVersion)
                 ? setValidVersion(true)
                 : setValidVersion(false)
+
+            if (shouldUseNewTracker(apiVersion)) {
+                onChange({
+                    ...value,
+                    [CODE]: newTrackerVersion,
+                })
+                setTracker(true)
+            }
         }
     }, [apiVersion])
 

--- a/src/components/noticeAlert/TrackerImporterInfo.js
+++ b/src/components/noticeAlert/TrackerImporterInfo.js
@@ -1,0 +1,12 @@
+import i18n from '@dhis2/d2-i18n'
+import React from 'react'
+import NoticeAlert from './NoticeAlert'
+
+export const TrackerImporterInfo = () => (
+    <NoticeAlert
+        title={i18n.t('New Tracker Importer')}
+        notice={i18n.t(
+            'If the API version is 2.40 or higher, please note that the New Tracker Importer should be used as the default option.'
+        )}
+    />
+)

--- a/src/components/noticeAlert/index.js
+++ b/src/components/noticeAlert/index.js
@@ -1,3 +1,4 @@
 export * from './NoticeError'
+export * from './TrackerImporterInfo'
 export * from './VisualizationsError'
 export * from './VisualizationsInfo'

--- a/src/modules/populateDefaultSettings.js
+++ b/src/modules/populateDefaultSettings.js
@@ -1,4 +1,7 @@
-import { defaultShareScreen } from '../components/field'
+import {
+    defaultShareScreen,
+    defaultTrackerImporterVersion,
+} from '../components/field'
 import { androidSettingsDefault } from '../constants/android-settings'
 import { dataSetSettingsDefault } from '../constants/data-set-settings'
 import { programSettingsDefault } from '../constants/program-settings'
@@ -22,7 +25,7 @@ export const populateObject = (type) => {
             object = {
                 metadataSync: androidSettingsDefault.metadataSync,
                 dataSync: androidSettingsDefault.dataSync,
-                newTrackerImporter: false,
+                newTrackerImporter: defaultTrackerImporterVersion,
             }
             break
         case DEFAULT_PROGRAM:

--- a/src/pages/Synchronization/Global/GlobalSettings.js
+++ b/src/pages/Synchronization/Global/GlobalSettings.js
@@ -8,7 +8,7 @@ import {
     TrackerImporter,
 } from '../../../components/field'
 import FooterStripButtons from '../../../components/footerStripButton/FooterStripButtons'
-import ManualSyncAlert from '../../../components/noticeAlert/ManualSyncAlert'
+import { TrackerImporterInfo } from '../../../components/noticeAlert'
 import Page from '../../../components/page/Page'
 import { authorityQuery } from '../../../modules/apiLoadFirstSetup'
 import {
@@ -73,7 +73,7 @@ const GlobalSettings = () => {
         >
             {settings && (
                 <>
-                    <ManualSyncAlert />
+                    <TrackerImporterInfo />
 
                     <MetadataSync
                         value={settings}


### PR DESCRIPTION
If the current API version is 2.40 or higher, the app should use the new tracker importer as the default option.

[DHIS2-14741](https://dhis2.atlassian.net/browse/DHIS2-14741)

- add a notice box/alert to inform the new tracker importer should be used as default
- use new tracker importer should be checked as a default option

_Notice box and default value_
![image](https://user-images.githubusercontent.com/29384664/219369074-8f13d6c6-22c4-448e-994c-cbc69d717e24.png)

_Datastore_
![image](https://user-images.githubusercontent.com/29384664/219369357-2ddb4518-a789-4bf0-8c02-f5313ddcf970.png)

