### PR TITLE
fix: allow set 0 reserved values [DHIS2-15652]

### DIFF
--- a/src/components/field/ReservedValues.js
+++ b/src/components/field/ReservedValues.js
@@ -25,6 +25,7 @@ export const ReservedValues = ({ onChange, value, ...props }) => {
             value={value[CODE]}
             warning={value[CODE] >= MAXVALUE}
             step="10"
+            min="0"
             inputWidth="120px"
             validationText={i18n.t(
                 'Recommended maximum is {{maxValue}} reserved values',

--- a/src/pages/General/helper.js
+++ b/src/pages/General/helper.js
@@ -1,3 +1,4 @@
+import isNil from 'lodash/isNil'
 import {
     defaultEncryptDB,
     defaultReservedValues,
@@ -41,8 +42,15 @@ export const createInitialValues = (prevGeneralDetails) => ({
     matomoID: prevGeneralDetails.matomoID || '',
     smsGateway: prevGeneralDetails.smsGateway || '',
     smsResultSender: prevGeneralDetails.smsResultSender || '',
-    reservedValues: prevGeneralDetails.reservedValues || defaultReservedValues,
+    reservedValues: validReservedValue(prevGeneralDetails.reservedValues),
     encryptDB: prevGeneralDetails.encryptDB || defaultEncryptDB,
     allowScreenCapture:
         prevGeneralDetails.allowScreenCapture || defaultShareScreen,
 })
+
+const validReservedValue = (value) => {
+    if (isNil(value) || !isValidValue(value)) {
+        return defaultReservedValues
+    }
+    return value
+}


### PR DESCRIPTION
This PR allows users to set the value 0 for reserved values. In case there is no value set, it uses the default value.

[DHIS2-15652](https://dhis2.atlassian.net/browse/DHIS2-15652)

![image](https://github.com/dhis2/android-settings-app/assets/29384664/2655e3c7-4251-428b-888b-004065595951)
