### PR TITLE
feat: add message of the day to general settings

### DIFF
--- a/src/pages/General/GeneralSettings.js
+++ b/src/pages/General/GeneralSettings.js
@@ -7,6 +7,7 @@ import {
     EncryptDB,
     MatomoId,
     MatomoUrl,
+    MessageOfDay,
     ReservedValues,
     ShareScreen,
     SmsGateway,
@@ -106,6 +107,11 @@ const GeneralSettings = () => {
                         disabled={disable}
                     />
                     <ReservedValues
+                        value={settings}
+                        onChange={setSettings}
+                        disabled={disable}
+                    />
+                    <MessageOfDay
                         value={settings}
                         onChange={setSettings}
                         disabled={disable}

--- a/src/pages/General/helper.js
+++ b/src/pages/General/helper.js
@@ -46,6 +46,7 @@ export const createInitialValues = (prevGeneralDetails) => ({
     encryptDB: prevGeneralDetails.encryptDB || defaultEncryptDB,
     allowScreenCapture:
         prevGeneralDetails.allowScreenCapture || defaultShareScreen,
+    messageOfTheDay: prevGeneralDetails.messageOfTheDay,
 })
 
 const validReservedValue = (value) => {


### PR DESCRIPTION
This PR adds a Text area that will allow admins to create customs messages to communicate with users.

[DHIS2-12630](https://jira.dhis2.org/browse/DHIS2-12630)

![image](https://github.com/dhis2/android-settings-app/assets/29384664/8571c785-48cb-4265-9870-bba02573e0f0)
