### PR TITLE
fix: title and short name fields empty who nutrition

### DIFF
--- a/src/components/analytics/VisualizationType.js
+++ b/src/components/analytics/VisualizationType.js
@@ -73,6 +73,8 @@ export const VisualizationType = ({
                 ...createInitialValues(''),
                 program: value.program,
                 programStage: value.programStage,
+                name: value.name,
+                shortName: value.shortName,
                 [e.name]: e.selected || e.value,
             })
         } else {

--- a/src/pages/Analytics/TEI/helper.js
+++ b/src/pages/Analytics/TEI/helper.js
@@ -132,7 +132,7 @@ export const updateDataElementsList = (programId, refetch, updateList) => {
     if (programId) {
         refetch({ programId }).then((result) => {
             const dataElements =
-                result.programStages.programStageDataElements || []
+                result?.programStages.programStageDataElements || []
             const options = []
 
             dataElements.map((dataElement) => {
@@ -160,7 +160,7 @@ export const updateAttributesList = ({
     if (programId) {
         refetch({ programId }).then((result) => {
             const attributes =
-                result.programs.programTrackedEntityAttributes || []
+                result?.programs.programTrackedEntityAttributes || []
             const options = []
 
             attributes.map((attribute) => {
@@ -190,7 +190,7 @@ export const updateAttributesList = ({
 export const updateProgramIndicatorsList = (programId, refetch, updateList) => {
     if (programId) {
         refetch({ programId }).then((result) => {
-            const programIndicators = result.programs.programIndicators || []
+            const programIndicators = result?.programs.programIndicators || []
             const options = programIndicators.map((program) => ({
                 label: program.name,
                 id: program.id,


### PR DESCRIPTION
This PR keeps the same behavior for all visualization-type options by holding the name and short name even after selecting the WHO nutrition radio button.

[DHIS2-16370](https://jira.dhis2.org/browse/DHIS2-16370)

_Single Value visualization type_
![image](https://github.com/dhis2/android-settings-app/assets/29384664/f62b6f87-7bed-4e5d-b36c-b739ba203cb0)

_WHO nutrition visualization type_
![image](https://github.com/dhis2/android-settings-app/assets/29384664/6412b8fb-0aeb-4369-a4b0-7e0ae68c6196)


[DHIS2-16370]: https://dhis2.atlassian.net/browse/DHIS2-16370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ