### PR TITLE
fix: user sync test runs without results

### DIFF
--- a/src/pages/Synchronization/UserSyncTest/helper.js
+++ b/src/pages/Synchronization/UserSyncTest/helper.js
@@ -239,11 +239,16 @@ const getTestElements = async (user, dataEngine) => {
 }
 
 export const joinObjectsById = (array) => {
-    const joinedArray = []
+    if (isEmpty(array)) {
+        return []
+    }
 
-    array
-        .reduce((array1, array2) => unionBy(array1, array2, 'id'))
-        .map((e) => joinedArray.push(e.id))
+    const joinedArray = array
+        .reduce(
+            (result, currentArray) => unionBy(result, currentArray, 'id'),
+            []
+        )
+        .map((e) => e.id)
 
     return parseUniqList(joinedArray)
 }


### PR DESCRIPTION
This PR fixes the no value bug when User Sync test runs without results for some users.

[DHIS2-16348](https://jira.dhis2.org/browse/DHIS2-16348)

_Fixed User sync test_
![image](https://github.com/dhis2/android-settings-app/assets/29384664/dfb1636c-b600-428b-b6f6-d241d13303d4)

_Error empty array_
![image](https://github.com/dhis2/android-settings-app/assets/29384664/7b3ce847-1fdd-4a60-8111-3ebfcaec0898)



[DHIS2-16348]: https://dhis2.atlassian.net/browse/DHIS2-16348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ