### PR TITLE
feat: bypass DHIS2 version [DHIS2-15905]

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2023-11-21T14:06:37.126Z\n"
-"PO-Revision-Date: 2023-11-21T14:06:37.126Z\n"
+"POT-Creation-Date: 2024-03-14T01:10:43.345Z\n"
+"PO-Revision-Date: 2024-03-14T01:10:43.345Z\n"
 
 msgid ""
 "The initial configuration of the app has been completed and it is now ready "
@@ -230,6 +230,49 @@ msgstr "Weight for height"
 msgid "Choose WHO visualization type"
 msgstr "Choose WHO visualization type"
 
+msgid "Bypass"
+msgstr "Bypass"
+
+msgid "Require"
+msgstr "Require"
+
+msgid "{{bypass}} DHIS2 Version Validation"
+msgstr "{{bypass}} DHIS2 Version Validation"
+
+msgid ""
+"Use this option to enforce strict version validation when connecting to "
+"DHIS2 instances."
+msgstr ""
+"Use this option to enforce strict version validation when connecting to "
+"DHIS2 instances."
+
+msgid ""
+"This ensures that only supported DHIS2 versions are accessed, maintaining "
+"compatibility and security standards."
+msgstr ""
+"This ensures that only supported DHIS2 versions are accessed, maintaining "
+"compatibility and security standards."
+
+msgid ""
+"Enabling this option allows you to proceed with connecting to DHIS2 "
+"instances even if they are not officially supported."
+msgstr ""
+"Enabling this option allows you to proceed with connecting to DHIS2 "
+"instances even if they are not officially supported."
+
+msgid ""
+"Use this with caution and ensure compatibility and security measures are in "
+"place."
+msgstr ""
+"Use this with caution and ensure compatibility and security measures are in "
+"place."
+
+msgid "Validate version"
+msgstr "Validate version"
+
+msgid "Bypass version"
+msgstr "Bypass version"
+
 msgid "Delete {{typeName}}"
 msgstr "Delete {{typeName}}"
 
@@ -357,6 +400,12 @@ msgstr ""
 
 msgid "Save"
 msgstr "Save"
+
+msgid "Bypass DHIS2 Version"
+msgstr "Bypass DHIS2 Version"
+
+msgid "Bypass the validation process for DHIS2 version compatibility"
+msgstr "Bypass the validation process for DHIS2 version compatibility"
 
 msgid "30 Minutes"
 msgstr "30 Minutes"

--- a/src/components/dialog/DialogBypass.js
+++ b/src/components/dialog/DialogBypass.js
@@ -1,0 +1,102 @@
+import i18n from '@dhis2/d2-i18n'
+import {
+    Modal,
+    ModalTitle,
+    ModalContent,
+    ModalActions,
+    ButtonStrip,
+    Button,
+} from '@dhis2/ui'
+import PropTypes from 'prop-types'
+import React from 'react'
+
+const bypassTitles = {
+    bypass: i18n.t('Bypass'),
+    require: i18n.t('Require'),
+}
+
+const DialogBypass = ({ openDialog, onClose, handleBypass, checked }) => {
+    let bypass
+
+    if (checked) {
+        bypass = bypassTitles.require
+    } else {
+        bypass = bypassTitles.bypass
+    }
+
+    return (
+        <>
+            {openDialog && (
+                <Modal small onClose={onClose} position="middle">
+                    <ModalTitle>
+                        {i18n.t('{{bypass}} DHIS2 Version Validation', {
+                            bypass,
+                        })}
+                    </ModalTitle>
+                    <ModalContent>
+                        <>
+                            {checked ? (
+                                <>
+                                    <p>
+                                        {i18n.t(
+                                            'Use this option to enforce strict version validation when connecting to DHIS2 instances.'
+                                        )}
+                                    </p>
+                                    <p>
+                                        {i18n.t(
+                                            'This ensures that only supported DHIS2 versions are accessed, maintaining compatibility and security standards.'
+                                        )}
+                                    </p>
+                                </>
+                            ) : (
+                                <>
+                                    <p>
+                                        {i18n.t(
+                                            'Enabling this option allows you to proceed with connecting to DHIS2 instances even if they are not officially supported.'
+                                        )}
+                                    </p>
+                                    <p>
+                                        {i18n.t(
+                                            'Use this with caution and ensure compatibility and security measures are in place.'
+                                        )}
+                                    </p>
+                                </>
+                            )}
+                        </>
+                    </ModalContent>
+                    <ModalActions>
+                        <ButtonStrip end>
+                            <Button onClick={onClose}>
+                                {i18n.t('Cancel')}
+                            </Button>
+                            {checked ? (
+                                <Button
+                                    primary
+                                    onClick={() => handleBypass(checked)}
+                                >
+                                    {i18n.t('Validate version')}
+                                </Button>
+                            ) : (
+                                <Button
+                                    destructive
+                                    onClick={() => handleBypass(checked)}
+                                >
+                                    {i18n.t('Bypass version')}
+                                </Button>
+                            )}
+                        </ButtonStrip>
+                    </ModalActions>
+                </Modal>
+            )}
+        </>
+    )
+}
+
+DialogBypass.propTypes = {
+    checked: PropTypes.bool.isRequired,
+    openDialog: PropTypes.bool.isRequired,
+    onClose: PropTypes.func.isRequired,
+    handleBypass: PropTypes.func.isRequired,
+}
+
+export default DialogBypass

--- a/src/components/field/BypassDHIS2Version.js
+++ b/src/components/field/BypassDHIS2Version.js
@@ -1,0 +1,53 @@
+import i18n from '@dhis2/d2-i18n'
+import PropTypes from 'prop-types'
+import React, { useState } from 'react'
+import DialogBypass from '../dialog/DialogBypass'
+import { CheckboxField } from './CheckboxField'
+
+const CODE = 'bypassDHIS2VersionCheck'
+
+export const defaultBypassDHIS2Version = false
+
+export const BypassDHIS2Version = ({ value, onChange, ...props }) => {
+    const [open, setOpen] = useState(false)
+
+    const handleCheckbox = () => {
+        setOpen(true)
+    }
+
+    const onCloseDialog = () => {
+        setOpen(false)
+    }
+
+    const handleBypassChange = (checked) => {
+        onChange({ ...value, [CODE]: !checked })
+        onCloseDialog()
+    }
+
+    return (
+        <>
+            <CheckboxField
+                name={CODE}
+                label={i18n.t('Bypass DHIS2 Version')}
+                helpText={i18n.t(
+                    'Bypass the validation process for DHIS2 version compatibility'
+                )}
+                checked={value[CODE]}
+                onChange={handleCheckbox}
+                {...props}
+            />
+
+            <DialogBypass
+                openDialog={open}
+                handleBypass={handleBypassChange}
+                onClose={onCloseDialog}
+                checked={value[CODE]}
+            />
+        </>
+    )
+}
+
+BypassDHIS2Version.propTypes = {
+    value: PropTypes.object,
+    onChange: PropTypes.func,
+}

--- a/src/components/field/index.js
+++ b/src/components/field/index.js
@@ -1,5 +1,6 @@
 export * from './AddNewSetting'
 export * from './ButtonField'
+export * from './BypassDHIS2Version'
 export * from './CheckboxField'
 export * from './DataSync'
 export * from './DisableReferral'

--- a/src/pages/General/GeneralSettings.js
+++ b/src/pages/General/GeneralSettings.js
@@ -4,6 +4,7 @@ import isEqual from 'lodash/isEqual'
 import React, { useEffect, useState } from 'react'
 import { useIsAuthorized } from '../../auth'
 import {
+    BypassDHIS2Version,
     EncryptDB,
     MatomoId,
     MatomoUrl,
@@ -117,6 +118,11 @@ const GeneralSettings = () => {
                         disabled={disable}
                     />
                     <ShareScreen
+                        value={settings}
+                        onChange={setSettings}
+                        disabled={disable}
+                    />
+                    <BypassDHIS2Version
                         value={settings}
                         onChange={setSettings}
                         disabled={disable}

--- a/src/pages/General/helper.js
+++ b/src/pages/General/helper.js
@@ -1,6 +1,7 @@
 import isNil from 'lodash/isNil'
 import map from 'lodash/map'
 import {
+    defaultBypassDHIS2Version,
     defaultEncryptDB,
     defaultReservedValues,
     defaultShareScreen,
@@ -47,6 +48,8 @@ export const createInitialValues = (prevGeneralDetails) => ({
     encryptDB: prevGeneralDetails.encryptDB || defaultEncryptDB,
     allowScreenCapture:
         prevGeneralDetails.allowScreenCapture || defaultShareScreen,
+    bypassDHIS2VersionCheck:
+        prevGeneralDetails.bypassDHIS2VersionCheck || defaultBypassDHIS2Version,
     experimentalFeatures: prevGeneralDetails.experimentalFeatures || [],
 })
 


### PR DESCRIPTION
This PR allows users to skip DHIS2 supported versions validation.

[DHIS2-15905](https://jira.dhis2.org/browse/DHIS2-15905)

_Uncheck Bypass version_
![image](https://github.com/dhis2/android-settings-app/assets/29384664/a2ee49f1-256f-4f1e-8603-008e523f0ee3)

_Dialog Bypass version_
![image](https://github.com/dhis2/android-settings-app/assets/29384664/b7f0eabe-3a64-4db0-afb2-1fbc16b2664f)

_Check Bypass version_
![image](https://github.com/dhis2/android-settings-app/assets/29384664/70411a03-ebe7-4d49-8e0d-8b4cd78ad206)

_Dialog Require validation_
![image](https://github.com/dhis2/android-settings-app/assets/29384664/1c3bd134-6fa0-45c7-b16b-8e336a6366cb)


[DHIS2-15905]: https://dhis2.atlassian.net/browse/DHIS2-15905?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ