### PR TITLE
feat: add dataSetConfiguration to home and programs [DHIS2-19025]

### DIFF
--- a/src/pages/Appearance/Home/HomeAppearance.js
+++ b/src/pages/Appearance/Home/HomeAppearance.js
@@ -16,6 +16,7 @@ const HomeAppearance = () => {
     const {
         load,
         home,
+        dataSetConfiguration,
         programConfiguration,
         completionSpinner,
         programSettings,
@@ -52,6 +53,7 @@ const HomeAppearance = () => {
         const settingsToSave = {
             programConfiguration,
             completionSpinner,
+            dataSetConfiguration,
             filterSorting: {
                 home: settings,
                 programSettings,

--- a/src/pages/Appearance/Programs/ProgramsAppearance.js
+++ b/src/pages/Appearance/Programs/ProgramsAppearance.js
@@ -26,6 +26,7 @@ const ProgramsAppearance = () => {
     const {
         load,
         dataSetSettings,
+        dataSetConfiguration,
         programConfiguration,
         home,
         programSettings,
@@ -108,6 +109,7 @@ const ProgramsAppearance = () => {
                     },
                 },
             },
+            dataSetConfiguration,
         }
         await mutate({ settings: settingsToSave })
     }


### PR DESCRIPTION
This PR add `dataSetConfiguration` key when updating the home and program appearance.
The `dataSetConfiguration` key was created to configure the maps/location for dataSets (only specific settings).

[DHIS2-19025](https://jira.dhis2.org/browse/DHIS2-19025)

[DHIS2-19025]: https://dhis2.atlassian.net/browse/DHIS2-19025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ