### PR TITLE
feat: global completion spinner default value [DHIS2-19398]

### DIFF
--- a/src/pages/Appearance/Programs/__tests__/createInitialGlobalSpinner.test.js
+++ b/src/pages/Appearance/Programs/__tests__/createInitialGlobalSpinner.test.js
@@ -1,0 +1,58 @@
+import { createInitialGlobalSpinner } from '../helper'
+
+test('Generate default values', () => {
+    const result = {
+        completionSpinner: false,
+        disableReferrals: false,
+        disableCollapsibleSections: false,
+    }
+
+    expect(createInitialGlobalSpinner({})).toMatchObject(result)
+})
+
+test('Create global spinner values', () => {
+    const initialValues = {
+        completionSpinner: true,
+        disableReferrals: false,
+        disableCollapsibleSections: true,
+    }
+
+    const result = {
+        completionSpinner: true,
+        disableReferrals: false,
+        disableCollapsibleSections: true,
+    }
+
+    expect(createInitialGlobalSpinner(initialValues)).toMatchObject(result)
+})
+
+test('Create global spinner values and add default values', () => {
+    const initialValues = {
+        disableReferrals: false,
+        disableCollapsibleSections: true,
+    }
+
+    const result = {
+        completionSpinner: false,
+        disableReferrals: false,
+        disableCollapsibleSections: true,
+    }
+
+    expect(createInitialGlobalSpinner(initialValues)).toMatchObject(result)
+})
+
+test('Create global spinner values and add default values', () => {
+    const initialValues = {
+        completionSpinner: null,
+        disableReferrals: false,
+        disableCollapsibleSections: true,
+    }
+
+    const result = {
+        completionSpinner: false,
+        disableReferrals: false,
+        disableCollapsibleSections: true,
+    }
+
+    expect(createInitialGlobalSpinner(initialValues)).toMatchObject(result)
+})

--- a/src/pages/Appearance/Programs/helper.js
+++ b/src/pages/Appearance/Programs/helper.js
@@ -66,15 +66,17 @@ export const createInitialSpecificValues = (prevDetails) => ({
     followUp: prevDetails.followUp || filterSortingDefault,
 })
 
-export const createInitialGlobalSpinner = (prevDetails = {}) => {
-    const {
-        completionSpinner = false,
-        disableReferrals = false,
-        disableCollapsibleSections = false,
-    } = prevDetails
-
-    return { completionSpinner, disableReferrals, disableCollapsibleSections }
-}
+export const createInitialGlobalSpinner = (prevDetails) => ({
+    completionSpinner: !isNil(prevDetails.completionSpinner)
+        ? prevDetails.completionSpinner
+        : false,
+    disableReferrals: !isNil(prevDetails.disableReferrals)
+        ? prevDetails.disableReferrals
+        : false,
+    disableCollapsibleSections: !isNil(prevDetails.disableCollapsibleSections)
+        ? prevDetails.disableCollapsibleSections
+        : false,
+})
 
 export const createInitialGlobalSpinnerPrevious = (prevDetails) => {
     defaults(prevDetails, {

--- a/src/pages/Appearance/Programs/helper.js
+++ b/src/pages/Appearance/Programs/helper.js
@@ -66,15 +66,15 @@ export const createInitialSpecificValues = (prevDetails) => ({
     followUp: prevDetails.followUp || filterSortingDefault,
 })
 
-export const createInitialGlobalSpinner = (prevDetails) => ({
-    completionSpinner: prevDetails.completionSpinner,
-    disableReferrals: !isNil(prevDetails.disableReferrals)
-        ? prevDetails.disableReferrals
-        : false,
-    disableCollapsibleSections: !isNil(prevDetails.disableCollapsibleSections)
-        ? prevDetails.disableCollapsibleSections
-        : false,
-})
+export const createInitialGlobalSpinner = (prevDetails = {}) => {
+    const {
+        completionSpinner = false,
+        disableReferrals = false,
+        disableCollapsibleSections = false,
+    } = prevDetails
+
+    return { completionSpinner, disableReferrals, disableCollapsibleSections }
+}
 
 export const createInitialGlobalSpinnerPrevious = (prevDetails) => {
     defaults(prevDetails, {


### PR DESCRIPTION
This PR adds a default value to global completion spinner.

[DHIS2-19398](https://jira.dhis2.org/browse/DHIS2-19398)

Default value: `false` (unchecked)

[DHIS2-19398]: https://dhis2.atlassian.net/browse/DHIS2-19398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ