### PR TITLE
feat: add metadata sync periods [DHIS2-20742]

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2025-12-02T14:50:10.042Z\n"
-"PO-Revision-Date: 2025-12-02T14:50:10.043Z\n"
+"POT-Creation-Date: 2026-02-25T15:14:00.274Z\n"
+"PO-Revision-Date: 2026-02-25T15:14:00.274Z\n"
 
 msgid ""
 "The initial configuration of the app has been completed and it is now ready "
@@ -495,6 +495,12 @@ msgid ""
 msgstr ""
 "Use this message to communicate with users in order to display important "
 "information"
+
+msgid "6 hours"
+msgstr "6 hours"
+
+msgid "12 hours"
+msgstr "12 hours"
 
 msgid "1 Week"
 msgstr "1 Week"

--- a/src/components/field/MetadataSync.jsx
+++ b/src/components/field/MetadataSync.jsx
@@ -1,4 +1,3 @@
-import { useConfig } from '@dhis2/app-runtime'
 import i18n from '@dhis2/d2-i18n'
 import PropTypes from 'prop-types'
 import React from 'react'
@@ -9,18 +8,16 @@ export const defaultMetadataSync = '24h'
 const CODE = 'metadataSync'
 export const metadataOptions = [
     {
-        value: defaultMetadataSync,
-        label: i18n.t('1 Day'),
-    },
-    {
         value: 'EVERY_6_HOURS',
-        label: i18n.t('6 hours'),
-        minApiVersion: 43,
+        label: i18n.t('6 Hours'),
     },
     {
         value: 'EVERY_12_HOURS',
-        label: i18n.t('12 hours'),
-        minApiVersion: 43,
+        label: i18n.t('12 Hours'),
+    },
+    {
+        value: defaultMetadataSync,
+        label: i18n.t('1 Day'),
     },
     {
         value: '7d',
@@ -32,32 +29,17 @@ export const metadataOptions = [
     },
 ]
 
-export const MetadataSync = ({ value, onChange, ...props }) => {
-    const { apiVersion } = useConfig()
-    const options = metadataOptions
-        .filter((option) => {
-            if (option.minApiVersion && apiVersion < option.minApiVersion) {
-                return false
-            }
-            return true
-        })
-        .map((option) => ({
-            label: option.label,
-            value: option.value,
-        }))
-
-    return (
-        <SyncSelect
-            name={CODE}
-            label={i18n.t('How often should metadata sync?')}
-            selected={value[CODE]}
-            onChange={onChange}
-            options={options}
-            settings={value}
-            {...props}
-        />
-    )
-}
+export const MetadataSync = ({ value, onChange, ...props }) => (
+    <SyncSelect
+        name={CODE}
+        label={i18n.t('How often should metadata sync?')}
+        selected={value[CODE]}
+        onChange={onChange}
+        options={metadataOptions}
+        settings={value}
+        {...props}
+    />
+)
 
 MetadataSync.propTypes = {
     value: PropTypes.object,

--- a/src/components/field/MetadataSync.jsx
+++ b/src/components/field/MetadataSync.jsx
@@ -1,3 +1,4 @@
+import { useConfig } from '@dhis2/app-runtime'
 import i18n from '@dhis2/d2-i18n'
 import PropTypes from 'prop-types'
 import React from 'react'
@@ -12,6 +13,16 @@ export const metadataOptions = [
         label: i18n.t('1 Day'),
     },
     {
+        value: 'EVERY_6_HOURS',
+        label: i18n.t('6 hours'),
+        minApiVersion: 43,
+    },
+    {
+        value: 'EVERY_12_HOURS',
+        label: i18n.t('12 hours'),
+        minApiVersion: 43,
+    },
+    {
         value: '7d',
         label: i18n.t('1 Week'),
     },
@@ -21,17 +32,32 @@ export const metadataOptions = [
     },
 ]
 
-export const MetadataSync = ({ value, onChange, ...props }) => (
-    <SyncSelect
-        name={CODE}
-        label={i18n.t('How often should metadata sync?')}
-        selected={value[CODE]}
-        onChange={onChange}
-        options={metadataOptions}
-        settings={value}
-        {...props}
-    />
-)
+export const MetadataSync = ({ value, onChange, ...props }) => {
+    const { apiVersion } = useConfig()
+    const options = metadataOptions
+        .filter((option) => {
+            if (option.minApiVersion && apiVersion < option.minApiVersion) {
+                return false
+            }
+            return true
+        })
+        .map((option) => ({
+            label: option.label,
+            value: option.value,
+        }))
+
+    return (
+        <SyncSelect
+            name={CODE}
+            label={i18n.t('How often should metadata sync?')}
+            selected={value[CODE]}
+            onChange={onChange}
+            options={options}
+            settings={value}
+            {...props}
+        />
+    )
+}
 
 MetadataSync.propTypes = {
     value: PropTypes.object,

--- a/src/components/field/__tests__/MetadataSync.test.jsx
+++ b/src/components/field/__tests__/MetadataSync.test.jsx
@@ -1,0 +1,103 @@
+import { useConfig } from '@dhis2/app-runtime'
+import '@testing-library/jest-dom'
+import { render, screen, within, configure } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
+import React from 'react'
+import { MetadataSync } from '../MetadataSync.jsx'
+
+let mockOnChange
+
+jest.mock('@dhis2/app-runtime', () => ({
+    ...jest.requireActual('@dhis2/app-runtime'),
+    useConfig: jest.fn(),
+}))
+
+const mockedUseConfig = jest.mocked(useConfig)
+const mockStartValue = {
+    metadataSync: '24h',
+    dataSync: '24h',
+    trackerImporterVersion: 'V2',
+    trackerExporterVersion: 'V2',
+    fileMaxLengthBytes: null,
+}
+
+const expectSelectToExistWithOptions = async (
+    triggeringDiv,
+    { selected = undefined, options = [] },
+    screen
+) => {
+    const selectInput = within(triggeringDiv).getByTestId(
+        'dhis2-uicore-select-input'
+    )
+    expect(selectInput).toBeVisible()
+    if (selected) {
+        expect(selectInput).toHaveTextContent(selected)
+    }
+    await userEvent.click(selectInput)
+
+    const optionsWrapper = await screen.findByTestId(
+        'dhis2-uicore-select-menu-menuwrapper'
+    )
+    expect(optionsWrapper).toBeVisible()
+    const foundOptions = within(optionsWrapper).getAllByTestId(
+        'dhis2-uicore-singleselectoption'
+    )
+    expect(foundOptions).toHaveLength(options.length)
+    options.forEach((option, index) => {
+        expect(foundOptions[index]).toHaveTextContent(option.displayName)
+    })
+    await userEvent.click(selectInput)
+}
+
+beforeEach(() => {
+    jest.clearAllMocks()
+    mockOnChange = jest.fn()
+    configure({ testIdAttribute: 'data-test' })
+})
+
+describe('MetadataSynce', () => {
+    test('renders Metadata sync component with expanded options if v43', async () => {
+        mockedUseConfig.mockReturnValue({ apiVersion: 43 })
+        const expectedOptions = [
+            { displayName: '1 Day' },
+            { displayName: '6 hours' },
+            { displayName: '12 hours' },
+            { displayName: '1 Week' },
+            { displayName: 'Manual' },
+        ]
+        render(
+            <div data-test="testing-wrapper">
+                <MetadataSync onChange={mockOnChange} value={mockStartValue} />
+            </div>
+        )
+        expect(
+            screen.getByText(/How often should metadata sync?/i)
+        ).toBeInTheDocument()
+        await expectSelectToExistWithOptions(
+            screen.getByTestId('testing-wrapper'),
+            { options: expectedOptions, selected: '1 Day' },
+            screen
+        )
+    })
+    test('renders Metadata sync component with limited options if v42', async () => {
+        mockedUseConfig.mockReturnValue({ apiVersion: 42 })
+        const expectedOptions = [
+            { displayName: '1 Day' },
+            { displayName: '1 Week' },
+            { displayName: 'Manual' },
+        ]
+        render(
+            <div data-test="testing-wrapper">
+                <MetadataSync onChange={mockOnChange} value={mockStartValue} />
+            </div>
+        )
+        expect(
+            screen.getByText(/How often should metadata sync?/i)
+        ).toBeInTheDocument()
+        await expectSelectToExistWithOptions(
+            screen.getByTestId('testing-wrapper'),
+            { options: expectedOptions, selected: '1 Day' },
+            screen
+        )
+    })
+})

--- a/src/components/field/__tests__/MetadataSync.test.jsx
+++ b/src/components/field/__tests__/MetadataSync.test.jsx
@@ -1,4 +1,3 @@
-import { useConfig } from '@dhis2/app-runtime'
 import '@testing-library/jest-dom'
 import { render, screen, within, configure } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
@@ -7,12 +6,6 @@ import { MetadataSync } from '../MetadataSync.jsx'
 
 let mockOnChange
 
-jest.mock('@dhis2/app-runtime', () => ({
-    ...jest.requireActual('@dhis2/app-runtime'),
-    useConfig: jest.fn(),
-}))
-
-const mockedUseConfig = jest.mocked(useConfig)
 const mockStartValue = {
     metadataSync: '24h',
     dataSync: '24h',
@@ -56,32 +49,10 @@ beforeEach(() => {
 })
 
 describe('MetadataSynce', () => {
-    test('renders Metadata sync component with expanded options if v43', async () => {
-        mockedUseConfig.mockReturnValue({ apiVersion: 43 })
+    test('renders Metadata sync component with appropriate options', async () => {
         const expectedOptions = [
-            { displayName: '1 Day' },
-            { displayName: '6 hours' },
-            { displayName: '12 hours' },
-            { displayName: '1 Week' },
-            { displayName: 'Manual' },
-        ]
-        render(
-            <div data-test="testing-wrapper">
-                <MetadataSync onChange={mockOnChange} value={mockStartValue} />
-            </div>
-        )
-        expect(
-            screen.getByText(/How often should metadata sync?/i)
-        ).toBeInTheDocument()
-        await expectSelectToExistWithOptions(
-            screen.getByTestId('testing-wrapper'),
-            { options: expectedOptions, selected: '1 Day' },
-            screen
-        )
-    })
-    test('renders Metadata sync component with limited options if v42', async () => {
-        mockedUseConfig.mockReturnValue({ apiVersion: 42 })
-        const expectedOptions = [
+            { displayName: '6 Hours' },
+            { displayName: '12 Hours' },
             { displayName: '1 Day' },
             { displayName: '1 Week' },
             { displayName: 'Manual' },


### PR DESCRIPTION
See ticket: [DHIS2-20742](https://dhis2.atlassian.net/browse/DHIS2-20742)

This adds the options "6 Hours" and "12 Hours" for metadata sync options. (I've capitalised `Hours` in the label to be consistent with the other options; the ticket had `6 hours` and `12 hours`)

<img width="328" height="266" alt="image" src="https://github.com/user-attachments/assets/579af4da-b019-41f3-b0a2-dbb46c596d0d" />

[DHIS2-20742]: https://dhis2.atlassian.net/browse/DHIS2-20742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ