### PR TITLE
fix: predefined list is not saved on the first attempt [DHIS2-20674]

### DIFF
--- a/src/pages/Synchronization/Programs/populateProgramObject.js
+++ b/src/pages/Synchronization/Programs/populateProgramObject.js
@@ -28,6 +28,7 @@ export const populateProgramObject = (programType, settingsList) => {
                 enrollmentDownload: settingsList.enrollmentDownload,
                 enrollmentDateDownload: settingsList.enrollmentDateDownload,
                 updateDownload: settingsList.updateDownload,
+                filters: settingsList.filters,
             }
             break
         case WITHOUT_REGISTRATION:
@@ -35,6 +36,7 @@ export const populateProgramObject = (programType, settingsList) => {
                 settingDownload: settingsList.settingDownload,
                 eventsDownload: settingsList.eventsDownload,
                 eventDateDownload: settingsList.eventDateDownload,
+                filters: settingsList.filters,
             }
             break
         case GLOBAL:


### PR DESCRIPTION
This PR fixes the predefined list (filters/working list) that were not saved on the first attempt.

[DHIS2-20674](https://jira.dhis2.org/browse/DHIS2-20674)

_Saved on first attempt_
<img width="922" height="565" alt="image" src="https://github.com/user-attachments/assets/6b9b2a3f-6383-492b-a55a-32798af874f3" />

<img width="922" height="565" alt="image" src="https://github.com/user-attachments/assets/d5c183c8-2a54-4714-92b7-5e37893fd2b1" />


[DHIS2-20674]: https://dhis2.atlassian.net/browse/DHIS2-20674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ